### PR TITLE
Code Review: Basis for preferences window

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ module.exports = {
   APP_NAME: 'WebTorrent',
   APP_ICON: path.join(__dirname, 'static', 'WebTorrent.png'),
   INDEX: 'file://' + path.join(__dirname, 'renderer', 'index.html'),
+  PREFERENCES: 'file://' + path.join(__dirname, 'renderer', 'preferences.html'),
   SOUND_ADD: 'file://' + path.join(__dirname, 'static', 'sound', 'add.wav'),
   SOUND_DELETE: 'file://' + path.join(__dirname, 'static', 'sound', 'delete.wav'),
   SOUND_DISABLE: 'file://' + path.join(__dirname, 'static', 'sound', 'disable.wav'),

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -56,6 +56,10 @@ function init () {
       powerSaveBlocker.stop(powerSaveBlocked)
     }
   })
+
+  ipcMain.on('showSelectDownloadDirectory', function (e) {
+    menu.showSelectDownloadDirectory()
+  })
 }
 
 function setBounds (bounds) {

--- a/main/menu.js
+++ b/main/menu.js
@@ -4,6 +4,7 @@ module.exports = {
   onWindowHide: onWindowHide,
   onWindowShow: onWindowShow,
   showOpenTorrentFile: showOpenTorrentFile,
+  showSelectDownloadDirectory: showSelectDownloadDirectory,
   toggleFullScreen: toggleFullScreen
 }
 
@@ -43,8 +44,11 @@ function toggleFloatOnTop (flag) {
 
 function toggleDevTools () {
   debug('toggleDevTools')
-  if (windows.main) {
+  /* A quick hack to show dev tools for the preferences window if it's open */
+  if (!windows.preferences) {
     windows.main.toggleDevTools()
+  } else {
+    windows.preferences.toggleDevTools()
   }
 }
 
@@ -110,6 +114,21 @@ function showOpenTorrentFile () {
     filenames.forEach(function (filename) {
       windows.main.send('dispatch', 'addTorrent', filename)
     })
+  })
+}
+
+// Open the preferences window
+function showPreferencesWindow () {
+  windows.createPreferencesWindow()
+}
+
+function showSelectDownloadDirectory() {
+  electron.dialog.showOpenDialog(windows.preferences, {
+    title: 'Select a directory to save in.',
+    defaultPath: '/',
+    properties: [ 'openDirectory' ]
+  }, function (directoryname) {
+    windows.main.send('dispatch', 'setDefaultDownloadDirectory', directoryname)
   })
 }
 
@@ -266,6 +285,14 @@ function getAppMenuTemplate () {
         {
           label: 'About ' + name,
           role: 'about'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Preferences',
+          accelerator: 'Cmd+,',
+          click: () => showPreferencesWindow()
         },
         {
           type: 'separator'

--- a/main/menu.js
+++ b/main/menu.js
@@ -122,9 +122,9 @@ function showPreferencesWindow () {
   windows.createPreferencesWindow()
 }
 
-function showSelectDownloadDirectory() {
+function showSelectDownloadDirectory () {
   electron.dialog.showOpenDialog(windows.preferences, {
-    title: 'Select a directory to save in.',
+    title: 'Choose a folder for your downloads...',
     defaultPath: '/',
     properties: [ 'openDirectory' ]
   }, function (directoryname) {

--- a/main/windows.js
+++ b/main/windows.js
@@ -1,6 +1,8 @@
 var windows = module.exports = {
   main: null,
-  createMainWindow: createMainWindow
+  preferences: null,
+  createMainWindow: createMainWindow,
+  createPreferencesWindow: createPreferencesWindow
 }
 
 var config = require('../config')
@@ -59,4 +61,31 @@ function createMainWindow () {
   win.once('closed', function () {
     windows.main = null
   })
+}
+
+
+
+function createPreferencesWindow () {
+  if (!windows.preferences) {
+    var win = windows.preferences = new electron.BrowserWindow({
+      autoHideMenuBar: true, // Hide top menu bar unless Alt key is pressed (Windows, Linux)
+      backgroundColor: '#282828',
+      darkTheme: true, // Forces dark theme (GTK+3 only)
+      icon: config.APP_ICON,
+      resizable: false,
+      show: true, // Hide window until DOM finishes loading
+      title: 'Preferences',
+      titleBarStyle: 'hidden-inset', // Hide OS chrome, except traffic light buttons (OS X)
+      width: 480,
+      height: 38 + (120 * 2)
+    })
+    win.loadURL(config.PREFERENCES)
+
+    win.on('blur', menu.onWindowHide)
+    win.on('focus', menu.onWindowShow)
+
+    win.once('closed', function () {
+      windows.preferences = null
+    })
+  }
 }

--- a/main/windows.js
+++ b/main/windows.js
@@ -63,8 +63,6 @@ function createMainWindow () {
   })
 }
 
-
-
 function createPreferencesWindow () {
   if (!windows.preferences) {
     var win = windows.preferences = new electron.BrowserWindow({

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -675,6 +675,11 @@ body.drag .torrent-placeholder span {
 .preferences-table .action {
   flex: 1;
 }
+
+.preferences-table input {
+  width: auto;
+  color: #fff;
+}
 /*
  * MEDIA QUERIES
  */

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -659,6 +659,23 @@ body.drag .torrent-placeholder span {
 }
 
 /*
+ * PREFERENCES WINDOW
+ */
+.preferences-table {
+  padding: 10px;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+}
+
+.preferences-table .label {
+  flex: 0 0 150px;
+}
+
+.preferences-table .action {
+  flex: 1;
+}
+/*
  * MEDIA QUERIES
  */
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -262,6 +262,7 @@ function setupIpc () {
 
 function setDefaultDownloadDirectory (directory) {
   state.downloadPath = directory
+  update()
 }
 
 function detectDevices () {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -163,6 +163,9 @@ function dispatch (action, ...args) {
   if (action === 'addTorrent') {
     addTorrent(args[0] /* torrent */)
   }
+  if (action === 'setDefaultDownloadDirectory') {
+    setDefaultDownloadDirectory(args[0] /* directory */)
+  }
   if (action === 'showOpenTorrentFile') {
     ipcRenderer.send('showOpenTorrentFile')
   }
@@ -255,6 +258,10 @@ function setupIpc () {
     state.devices[device] = player
     update()
   })
+}
+
+function setDefaultDownloadDirectory (directory) {
+  state.downloadPath = directory
 }
 
 function detectDevices () {

--- a/renderer/preferences.html
+++ b/renderer/preferences.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="index.css" charset="utf-8">
+  </head>
+  <body>
+    <script async src="preferences.js"></script>
+  </body>
+</html>

--- a/renderer/preferences.js
+++ b/renderer/preferences.js
@@ -1,0 +1,62 @@
+var electron = require('electron')
+
+var vdom = require('virtual-dom')
+var hyperx = require('hyperx')
+var hx = hyperx(vdom.h)
+
+var main = require('main-loop')
+var loop = main({ times: 0 }, render, vdom)
+
+// Electron apps have two processes: a main process (node) runs first and starts
+// a renderer process (essentially a Chrome window). We're in the renderer process,
+// and this IPC channel receives from and sends messages to the main process
+var ipcRenderer = electron.ipcRenderer
+
+
+document.querySelector('body').appendChild(loop.target)
+
+function render (state) {
+  return getContent()
+
+  function getHeader() {
+    return hx`<div class='header'>
+      <div class='title'>Preferences</div>
+    </div>`
+  }
+
+  function getContent() {
+    return hx`<div class='content'>
+      <div class='preferences-table'>
+        <div class='label'>Download folder: </div>
+        <div class='action'
+        onclick=${(e) => dispatch('showSelectDownloadDirectory', e)}>
+        ${'[downloadPath]'}</div>
+      </div>
+    </div>`
+  }
+
+  function onclick () {
+    loop.update({ times: state.times + 1 })
+  }
+}
+
+function getDefaultDownloadDirectory() {
+  return
+}
+
+// Events from the UI never modify state directly. Instead they call dispatch()
+function dispatch (action, ...args) {
+  if (action === 'showSelectDownloadDirectory') {
+    ipcRenderer.send('showSelectDownloadDirectory')
+  }
+}
+
+function showSelectDownloadDirectory() {
+  electron.dialog.showOpenDialog(windows.preferences, {
+    title: 'Select a directory to save in.',
+    defaultPath: '/Users',
+    properties: [ 'openDirectory' ]
+  }, function (directoryname) {
+    windows.main.send('dispatch', 'setDefaultDownloadDirectory', directoryname)
+  })
+}

--- a/renderer/preferences.js
+++ b/renderer/preferences.js
@@ -12,36 +12,34 @@ var loop = main({ times: 0 }, render, vdom)
 // and this IPC channel receives from and sends messages to the main process
 var ipcRenderer = electron.ipcRenderer
 
-
 document.querySelector('body').appendChild(loop.target)
 
 function render (state) {
-  return getContent()
+  return hx`
+  <div class='app'>
+    ${getHeader()}
+    <div class='content'>${getContent()}</div>
+  </div>`
 
-  function getHeader() {
+  function getHeader () {
     return hx`<div class='header'>
       <div class='title'>Preferences</div>
     </div>`
   }
 
-  function getContent() {
-    return hx`<div class='content'>
+  function getContent () {
+    return hx`
       <div class='preferences-table'>
-        <div class='label'>Download folder: </div>
-        <div class='action'
-        onclick=${(e) => dispatch('showSelectDownloadDirectory', e)}>
-        ${'[downloadPath]'}</div>
+        <div class='label'>Download location: </div>
+        <div class='action'>
+        ${'[downloadPath]'}
+        <input type='button'
+        onclick=${(e) => dispatch('showSelectDownloadDirectory', e)}
+        value="Change">
+        </div>
       </div>
-    </div>`
+    `
   }
-
-  function onclick () {
-    loop.update({ times: state.times + 1 })
-  }
-}
-
-function getDefaultDownloadDirectory() {
-  return
 }
 
 // Events from the UI never modify state directly. Instead they call dispatch()
@@ -49,14 +47,4 @@ function dispatch (action, ...args) {
   if (action === 'showSelectDownloadDirectory') {
     ipcRenderer.send('showSelectDownloadDirectory')
   }
-}
-
-function showSelectDownloadDirectory() {
-  electron.dialog.showOpenDialog(windows.preferences, {
-    title: 'Select a directory to save in.',
-    defaultPath: '/Users',
-    properties: [ 'openDirectory' ]
-  }, function (directoryname) {
-    windows.main.send('dispatch', 'setDefaultDownloadDirectory', directoryname)
-  })
 }


### PR DESCRIPTION
Just wanting feedback on what I've written so far. This isn't ready for a merge.

Any review/suggestions would be great. Currently it doesn't seem to update the downloadPath, gotta look into that. Secondly, it doesn't currently display the existing downloadPath because I'm not sure what the best way to handle that is. I've tried to mimic the pattern used in the main app, which involved putting the dialogue box call in menu.js, not sure how I feel about that, but it's a central point that has access to windows.js. I figured there's a reason not to include windows.js within the preferences.js file itself.