### PR TITLE
Fixes

### DIFF
--- a/main/tray.js
+++ b/main/tray.js
@@ -6,17 +6,33 @@ var path = require('path')
 var electron = require('electron')
 var windows = require('./windows')
 
+var trayIcon
+
 function init () {
   // No tray icon on OSX
   if (process.platform === 'darwin') return
 
-  var trayIcon = new electron.Tray(path.join(__dirname, '..', 'static', 'WebTorrentSmall.png'))
+  trayIcon = new electron.Tray(path.join(__dirname, '..', 'static', 'WebTorrentSmall.png'))
 
   // On Windows, left click to open the app, right click for context menu
   // On Linux, any click (right or left) opens the context menu
   trayIcon.on('click', showApp)
+
+  // Show the tray context menu, and keep the available commands up to date
+  updateTrayMenu()
+  windows.main.on('show', updateTrayMenu)
+  windows.main.on('hide', updateTrayMenu)
+}
+
+function updateTrayMenu () {
+  var showHideMenuItem
+  if (windows.main.isVisible()) {
+    showHideMenuItem = { label: 'Hide to tray', click: hideApp }
+  } else {
+    showHideMenuItem = { label: 'Show', click: showApp }
+  }
   var contextMenu = electron.Menu.buildFromTemplate([
-    { label: 'Show', click: showApp },
+    showHideMenuItem,
     { label: 'Quit', click: quitApp }
   ])
   trayIcon.setContextMenu(contextMenu)
@@ -26,6 +42,12 @@ function showApp () {
   windows.main.show()
 }
 
+function hideApp () {
+  windows.main.hide()
+}
+
 function quitApp () {
-  electron.app.quit()
+  windows.main.send('dispatch', 'saveState') /* try to save state on exit */
+  electron.ipcMain.once('savedState', () => electron.app.quit())
+  setTimeout(() => electron.app.quit(), 2000) /* exit after at most 2 secs */
 }

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -77,9 +77,6 @@ function init () {
   })
   document.body.appendChild(vdomLoop.target)
 
-  // Save state on exit
-  window.addEventListener('beforeunload', saveState)
-
   // OS integrations:
   // ...drag and drop a torrent or video file to play or seed
   dragDrop('body', (files) => dispatch('onOpen', files))
@@ -316,6 +313,9 @@ function dispatch (action, ...args) {
     state.saved.skippedVersions.push(args[0] /* version */)
     saveState()
   }
+  if (action === 'saveState') {
+    saveState()
+  }
 
   // Update the virtual-dom, unless it's just a mouse move event
   if (action !== 'mediaMouseMoved') {
@@ -431,6 +431,7 @@ function saveState () {
 
   cfg.write(copy, function (err) {
     if (err) console.error(err)
+    ipcRenderer.send('savedState')
     update()
   })
 }

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -30,7 +30,7 @@ function TorrentList (state) {
     var torrent = state.client
       ? state.client.torrents.find((x) => x.infoHash === infoHash)
       : null
-    var isSelected = state.selectedInfoHash === infoHash
+    var isSelected = infoHash && state.selectedInfoHash === infoHash
 
     // Background image: show some nice visuals, like a frame from the movie, if possible
     var style = {}
@@ -51,13 +51,14 @@ function TorrentList (state) {
     //  playStatus turns the play button into a loading spinner or error icon
     if (torrentSummary.playStatus) classes.push(torrentSummary.playStatus)
     if (isSelected) classes.push('selected')
+    if (!infoHash) classes.push('disabled')
     classes = classes.join(' ')
     return hx`
       <div style=${style} class=${classes}
-        oncontextmenu=${dispatcher('openTorrentContextMenu', infoHash)}
-        onclick=${dispatcher('toggleSelectTorrent', infoHash)}>
+        oncontextmenu=${infoHash && dispatcher('openTorrentContextMenu', infoHash)}
+        onclick=${infoHash && dispatcher('toggleSelectTorrent', infoHash)}>
         ${renderTorrentMetadata(torrent, torrentSummary)}
-        ${renderTorrentButtons(torrentSummary)}
+        ${infoHash ? renderTorrentButtons(torrentSummary) : ''}
         ${isSelected ? renderTorrentDetails(torrent, torrentSummary) : ''}
       </div>
     `


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/169280/14181503/01f18438-f71c-11e5-8ba1-5aa9abe447b6.png)

* Show files immediately when seeding (fixes #208)
* Toggle show/hide in tray icon
* Save state when the app exits... for real this time
* Fix a bug where torrents would save in the "playState=requested" state, so you reopen the app and the spinner is still spinning