### PR TITLE
Windows/Linux: Fix broken Quit option in Tray icon

### DIFF
--- a/main/squirrel-win32.js
+++ b/main/squirrel-win32.js
@@ -16,15 +16,13 @@ var updateDotExe = path.join(process.execPath, '..', '..', 'Update.exe')
 
 function handleEvent (cmd) {
   if (cmd === '--squirrel-install') {
-    // App was installed.
-
-    // Install desktop/start menu shortcuts.
+    // App was installed. Install desktop/start menu shortcuts.
     createShortcuts(function () {
       // Ensure user sees install splash screen so they realize that Setup.exe actually
       // installed an application and isn't the application itself.
       setTimeout(function () {
         app.quit()
-      }, 5000)
+      }, 3000)
     })
     return true
   }

--- a/main/tray.js
+++ b/main/tray.js
@@ -4,20 +4,20 @@ module.exports = {
 
 var path = require('path')
 var electron = require('electron')
+
+var app = electron.app
+var Menu = electron.Menu
+var Tray = electron.Tray
+
 var windows = require('./windows')
 
 var trayIcon
 
 function init () {
-  if (process.platform === 'darwin') {
-    // Instead of relying on the tray icon quit button, listen for Cmd+Q
-    electron.app.once('before-quit', quitApp)
+  // OS X has no tray icon
+  if (process.platform === 'darwin') return
 
-    // OS X has no tray icon
-    return
-  }
-
-  trayIcon = new electron.Tray(path.join(__dirname, '..', 'static', 'WebTorrentSmall.png'))
+  trayIcon = new Tray(path.join(__dirname, '..', 'static', 'WebTorrentSmall.png'))
 
   // On Windows, left click to open the app, right click for context menu
   // On Linux, any click (right or left) opens the context menu
@@ -36,9 +36,9 @@ function updateTrayMenu () {
   } else {
     showHideMenuItem = { label: 'Show', click: showApp }
   }
-  var contextMenu = electron.Menu.buildFromTemplate([
+  var contextMenu = Menu.buildFromTemplate([
     showHideMenuItem,
-    { label: 'Quit', click: quitApp }
+    { label: 'Quit', click: () => app.quit() }
   ])
   trayIcon.setContextMenu(contextMenu)
 }
@@ -49,11 +49,4 @@ function showApp () {
 
 function hideApp () {
   windows.main.hide()
-}
-
-function quitApp (e) {
-  e.preventDefault()
-  windows.main.send('dispatch', 'saveState') /* try to save state on exit */
-  electron.ipcMain.once('savedState', () => electron.app.quit())
-  setTimeout(() => electron.app.quit(), 2000) /* exit after at most 2 secs */
 }


### PR DESCRIPTION
Fixes #288

This also cleans up the code by handling quit in the same way for all
platforms, removing the special case in tray.js for darwin.

We already have a 'before-quit' handler in main/index.js, so this is
now handled there :)