### PR TITLE
Name the .deb file consistently

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -207,8 +207,6 @@ function buildDarwin (cb) {
         verbose: true
       }
 
-      // TODO: Use the built-in `sign` opt to electron-packager that takes an options
-      // object as of v6.
       sign(signOpts, function (err) {
         if (err) return cb(err)
 
@@ -303,6 +301,7 @@ function buildLinux (packageType, cb) {
         info: {
           arch: 'amd64',
           targetDir: distPath,
+          targetName: BUILD_NAME + '.deb',
           scripts: {
             postinst: path.join(config.STATIC_PATH, 'linux', 'postinst'),
             postrm: path.join(config.STATIC_PATH, 'linux', 'postrm')
@@ -314,7 +313,8 @@ function buildLinux (packageType, cb) {
         expand: true,
         cwd: filesPath
       }], function (err, done) {
-        console.log(err || 'Created Linux .deb file.')
+        if (err) return console.error(err.message || err)
+        console.log('Created Linux .deb file.')
       })
     }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "electron-packager": "^6.0.0",
     "electron-winstaller": "^2.0.5",
     "gh-release": "^2.0.3",
-    "nobin-debian-installer": "^0.0.5",
+    "nobin-debian-installer": "feross/nobin-debian-installer",
     "plist": "^1.2.0",
     "rimraf": "^2.5.2",
     "standard": "^6.0.5"


### PR DESCRIPTION
Instead of "webtorrent-desktop_0.2.0-1_amd64.deb", name it "WebTorrent-v0.2.0.deb" like the rest of the built files.