### PR TITLE
Follow debian package name convention

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -301,7 +301,6 @@ function buildLinux (packageType, cb) {
         info: {
           arch: 'amd64',
           targetDir: distPath,
-          targetName: BUILD_NAME + '.deb',
           scripts: {
             postinst: path.join(config.STATIC_PATH, 'linux', 'postinst'),
             postrm: path.join(config.STATIC_PATH, 'linux', 'postrm')

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "electron-packager": "^6.0.0",
     "electron-winstaller": "^2.0.5",
     "gh-release": "^2.0.3",
-    "nobin-debian-installer": "feross/nobin-debian-installer",
+    "nobin-debian-installer": "^0.0.6",
     "plist": "^1.2.0",
     "rimraf": "^2.5.2",
     "standard": "^6.0.5"


### PR DESCRIPTION
package naming is handled by packager to follow debian convention
updated `nobin-debian-installer` to latest version (with your PRs) to handle change of name if needed
