### PR TITLE
Windows Installer improvements

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -115,7 +115,7 @@ var win32 = {
     // Original name of the file, not including a path. This information enables an
     // application to determine whether a file has been renamed by a user. The format of
     // the name depends on the file system for which the file was created.
-    OriginalFilename: 'WebTorrent.exe',
+    OriginalFilename: config.APP_NAME + '.exe',
 
     // Name of the product with which the file is distributed.
     ProductName: config.APP_NAME,
@@ -274,7 +274,7 @@ function buildWin32 (cb) {
       noMsi: true,
       outputDirectory: path.join(config.ROOT_PATH, 'dist'),
       productName: config.APP_NAME,
-      setupExe: BUILD_NAME + '.exe',
+      setupExe: config.APP_NAME + 'Setup-v' + config.APP_VERSION + '.exe',
       setupIcon: config.APP_ICON + '.ico',
       title: config.APP_NAME,
       usePackageJson: false,

--- a/bin/package.js
+++ b/bin/package.js
@@ -270,6 +270,7 @@ function buildWin32 (cb) {
       iconUrl: config.APP_ICON + '.ico',
       loadingGif: path.join(config.STATIC_PATH, 'loading.gif'),
       name: config.APP_NAME,
+      noMsi: true,
       outputDirectory: path.join(config.ROOT_PATH, 'dist'),
       productName: config.APP_NAME,
       setupExe: BUILD_NAME + '.exe',

--- a/bin/package.js
+++ b/bin/package.js
@@ -269,6 +269,7 @@ function buildWin32 (cb) {
       exe: config.APP_NAME + '.exe',
       iconUrl: config.APP_ICON + '.ico',
       loadingGif: path.join(config.STATIC_PATH, 'loading.gif'),
+      remoteReleases: config.AUTO_UPDATE_URL,
       name: config.APP_NAME,
       noMsi: true,
       outputDirectory: path.join(config.ROOT_PATH, 'dist'),

--- a/bin/package.js
+++ b/bin/package.js
@@ -267,7 +267,7 @@ function buildWin32 (cb) {
       // certificateFile: '', // TODO
       description: config.APP_NAME,
       exe: config.APP_NAME + '.exe',
-      iconUrl: config.APP_ICON + '.ico',
+      iconUrl: config.GITHUB_URL_RAW + '/static/' + config.APP_ICON + '.ico',
       loadingGif: path.join(config.STATIC_PATH, 'loading.gif'),
       remoteReleases: config.GITHUB_URL,
       name: config.APP_NAME,

--- a/bin/package.js
+++ b/bin/package.js
@@ -262,21 +262,21 @@ function buildWin32 (cb) {
 
     console.log('Creating Windows installer...')
     installer.createWindowsInstaller({
-      name: config.APP_NAME,
-      productName: config.APP_NAME,
-      title: config.APP_NAME,
-      exe: config.APP_NAME + '.exe',
-
       appDirectory: buildPath[0],
-      outputDirectory: path.join(config.ROOT_PATH, 'dist'),
-      version: pkg.version,
-      description: config.APP_NAME,
       authors: config.APP_TEAM,
-      iconUrl: config.APP_ICON + '.ico',
-      setupIcon: config.APP_ICON + '.ico',
       // certificateFile: '', // TODO
+      description: config.APP_NAME,
+      exe: config.APP_NAME + '.exe',
+      iconUrl: config.APP_ICON + '.ico',
+      loadingGif: path.join(config.STATIC_PATH, 'loading.gif'),
+      name: config.APP_NAME,
+      outputDirectory: path.join(config.ROOT_PATH, 'dist'),
+      productName: config.APP_NAME,
+      setupExe: BUILD_NAME + '.exe',
+      setupIcon: config.APP_ICON + '.ico',
+      title: config.APP_NAME,
       usePackageJson: false,
-      loadingGif: path.join(config.STATIC_PATH, 'loading.gif')
+      version: pkg.version
     }).then(function () {
       console.log('Created Windows installer.')
       cb(null, buildPath)

--- a/bin/package.js
+++ b/bin/package.js
@@ -269,7 +269,7 @@ function buildWin32 (cb) {
       exe: config.APP_NAME + '.exe',
       iconUrl: config.APP_ICON + '.ico',
       loadingGif: path.join(config.STATIC_PATH, 'loading.gif'),
-      remoteReleases: config.AUTO_UPDATE_URL,
+      remoteReleases: config.GITHUB_URL,
       name: config.APP_NAME,
       noMsi: true,
       outputDirectory: path.join(config.ROOT_PATH, 'dist'),

--- a/config.js
+++ b/config.js
@@ -22,6 +22,7 @@ module.exports = {
   CONFIG_TORRENT_PATH: path.join(applicationConfigPath(APP_NAME), 'Torrents'),
 
   GITHUB_URL: 'https://github.com/feross/webtorrent-desktop',
+  GITHUB_URL_RAW: 'https://raw.githubusercontent.com/feross/webtorrent-desktop/master',
 
   IS_PRODUCTION: isProduction(),
 

--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ module.exports = {
   APP_VERSION: APP_VERSION,
   APP_WINDOW_TITLE: APP_NAME + ' (BETA)',
 
-  AUTO_UPDATE_URL: 'https://webtorrent.io/app/update?version=' + APP_VERSION,
+  AUTO_UPDATE_URL: 'https://webtorrent.io/desktop/update?version=' + APP_VERSION,
   AUTO_UPDATE_CHECK_STARTUP_DELAY: 5 * 1000 /* 5 seconds */,
 
   CONFIG_PATH: applicationConfigPath(APP_NAME),

--- a/config.js
+++ b/config.js
@@ -21,6 +21,8 @@ module.exports = {
   CONFIG_POSTER_PATH: path.join(applicationConfigPath(APP_NAME), 'Posters'),
   CONFIG_TORRENT_PATH: path.join(applicationConfigPath(APP_NAME), 'Torrents'),
 
+  GITHUB_URL: 'https://github.com/feross/webtorrent-desktop',
+
   IS_PRODUCTION: isProduction(),
 
   ROOT_PATH: __dirname,

--- a/main/handlers.js
+++ b/main/handlers.js
@@ -59,12 +59,12 @@ function initWin32 () {
    */
 
   function registerProtocolHandlerWin32 (protocol, name, icon, command) {
-    setProtocol()
-
     var protocolKey = new Registry({
       hive: Registry.HKCU, // HKEY_CURRENT_USER
       key: '\\Software\\Classes\\' + protocol
     })
+
+    setProtocol()
 
     function setProtocol (err) {
       if (err) log.error(err.message)

--- a/main/menu.js
+++ b/main/menu.js
@@ -288,14 +288,14 @@ function getAppMenuTemplate () {
         },
         {
           label: 'Contribute on GitHub',
-          click: () => electron.shell.openExternal('https://github.com/feross/webtorrent-desktop')
+          click: () => electron.shell.openExternal(config.GITHUB_URL)
         },
         {
           type: 'separator'
         },
         {
           label: 'Report an Issue...',
-          click: () => electron.shell.openExternal('https://github.com/feross/webtorrent-desktop/issues')
+          click: () => electron.shell.openExternal(config.GITHUB_URL + '/issues')
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "electron-osx-sign": "^0.3.0",
     "electron-packager": "^6.0.0",
-    "electron-winstaller": "^2.0.5",
+    "electron-winstaller": "feross/windows-installer#build",
     "gh-release": "^2.0.3",
     "nobin-debian-installer": "^0.0.6",
     "plist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "email": "feross@feross.org",
     "url": "http://feross.org"
   },
+  "bin": {
+    "webtorrent-desktop": "./bin/cmd.js"
+  },
   "bugs": {
     "url": "https://github.com/feross/webtorrent-desktop/issues"
   },
@@ -42,9 +45,6 @@
     "rimraf": "^2.5.2",
     "standard": "^6.0.5"
   },
-  "optionalDependencies": {
-    "appdmg": "^0.3.6"
-  },
   "homepage": "https://webtorrent.io",
   "keywords": [
     "desktop",
@@ -54,6 +54,9 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "optionalDependencies": {
+    "appdmg": "^0.3.6"
+  },
   "productName": "WebTorrent",
   "repository": {
     "type": "git",
@@ -66,8 +69,5 @@
     "start": "electron .",
     "test": "standard",
     "update-authors": "./bin/update-authors.sh"
-  },
-  "bin": {
-    "webtorrent-desktop": "./bin/cmd.js"
   }
 }


### PR DESCRIPTION
- Name Setup.exe with WebTorrent Desktop version number
- Don't generate .msi file (it's not a real .msi, only meant for Enterprise group policy)
- Hardcode remote releases URL to ensure that delta packages get built correctly even if the previous built files don't exist on the build machine
- New update URL: /desktop/update
- Windows: Add valid iconUrl – for building on non-Windows platforms
