### PR TITLE
Uninstall handlers on Windows uninstall/npm run clean

### DIFF
--- a/bin/clean.js
+++ b/bin/clean.js
@@ -5,13 +5,18 @@
  * Useful for developers.
  */
 
-var config = require('../config')
 var os = require('os')
 var path = require('path')
 var pathExists = require('path-exists')
 var rimraf = require('rimraf')
 
+var config = require('../config')
+var handlers = require('../main/handlers')
+
 rimraf.sync(config.CONFIG_PATH)
 
 var tmpPath = path.join(pathExists.sync('/tmp') ? '/tmp' : os.tmpDir(), 'webtorrent')
 rimraf.sync(tmpPath)
+
+// Uninstall .torrent file and magnet link handlers
+handlers.uninstall()

--- a/main/index.js
+++ b/main/index.js
@@ -55,7 +55,7 @@ function init () {
     windows.createMainWindow()
     shortcuts.init()
     tray.init()
-    handlers.init()
+    handlers.install()
   })
 
   app.on('ipcReady', function () {

--- a/main/squirrel-win32.js
+++ b/main/squirrel-win32.js
@@ -11,6 +11,8 @@ var pathExists = require('path-exists')
 
 var app = electron.app
 
+var handlers = require('./handlers')
+
 var exeName = path.basename(process.execPath)
 var updateDotExe = path.join(process.execPath, '..', '..', 'Update.exe')
 
@@ -41,6 +43,10 @@ function handleEvent (cmd) {
     removeShortcuts(function () {
       app.quit()
     })
+
+    // Uninstall .torrent file and magnet link handlers
+    handlers.uninstall()
+
     return true
   }
 

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
     "network-address": "^1.1.0",
     "path-exists": "^2.1.0",
     "prettier-bytes": "^1.0.1",
+    "rimraf": "^2.5.2",
     "simple-get": "^2.0.0",
     "upload-element": "^1.0.1",
     "virtual-dom": "^2.1.1",
     "webtorrent": "^0.90.0",
-    "winreg": "^1.0.1"
+    "winreg": "feross/node-winreg"
   },
   "devDependencies": {
     "electron-osx-sign": "^0.3.0",
@@ -42,7 +43,6 @@
     "gh-release": "^2.0.3",
     "nobin-debian-installer": "^0.0.6",
     "plist": "^1.2.0",
-    "rimraf": "^2.5.2",
     "standard": "^6.0.5"
   },
   "homepage": "https://webtorrent.io",


### PR DESCRIPTION
Now we can call `handlers.uninstall()` to remove the .torrent file and magnet link associations. This gets called in the Windows uninstaller.

On Windows, the registry entries are removed ONLY if they still refer to WebTorrent Desktop.
On Linux, the .desktop and icon files are removed.
On OS X, there is no way to remove the association explicitly. Removing the program is sufficient.