### PR TITLE
Add crash reporting

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,6 +17,8 @@ module.exports = {
   AUTO_UPDATE_URL: 'https://webtorrent.io/desktop/update?version=' + APP_VERSION,
   AUTO_UPDATE_CHECK_STARTUP_DELAY: 5 * 1000 /* 5 seconds */,
 
+  CRASH_REPORT_URL: 'https://webtorrent.io/desktop/crash-report',
+
   CONFIG_PATH: applicationConfigPath(APP_NAME),
   CONFIG_POSTER_PATH: path.join(applicationConfigPath(APP_NAME), 'Posters'),
   CONFIG_TORRENT_PATH: path.join(applicationConfigPath(APP_NAME), 'Torrents'),

--- a/main/handlers.js
+++ b/main/handlers.js
@@ -30,14 +30,16 @@ function uninstall () {
 }
 
 function installDarwin () {
-  var electron = require('electron')
-  var app = electron.app
+  // TODO: Uncomment this once we upgrade past Electron 0.37.4.
 
-  // On OS X, only protocols that are listed in Info.plist can be set as the default
-  // handler at runtime.
-  app.setAsDefaultProtocolClient('magnet')
+  // var electron = require('electron')
+  // var app = electron.app
 
-  // File handlers are registered in the Info.plist.
+  // // On OS X, only protocols that are listed in Info.plist can be set as the default
+  // // handler at runtime.
+  // app.setAsDefaultProtocolClient('magnet')
+
+  // // File handlers are registered in the Info.plist.
 }
 
 function uninstallDarwin () {}

--- a/main/index.js
+++ b/main/index.js
@@ -1,6 +1,7 @@
 var electron = require('electron')
 
 var app = electron.app
+var crashReporter = electron.crashReporter
 var ipcMain = electron.ipcMain
 
 var autoUpdater = require('./auto-updater')
@@ -130,10 +131,9 @@ function processArgv (argv) {
 }
 
 function setupCrashReporter () {
-  // require('crash-reporter').start({
-  //   productName: 'WebTorrent',
-  //   companyName: 'WebTorrent',
-  //   submitURL: 'https://webtorrent.io/crash-report',
-  //   autoSubmit: true
-  // })
+  crashReporter.start({
+    companyName: config.APP_NAME,
+    productName: config.APP_NAME,
+    submitURL: 'https://webtorrent.io/desktop/crash-report'
+  })
 }

--- a/main/index.js
+++ b/main/index.js
@@ -134,6 +134,6 @@ function setupCrashReporter () {
   crashReporter.start({
     companyName: config.APP_NAME,
     productName: config.APP_NAME,
-    submitURL: 'https://webtorrent.io/desktop/crash-report'
+    submitURL: config.CRASH_REPORT_URL
   })
 }

--- a/main/squirrel-win32.js
+++ b/main/squirrel-win32.js
@@ -40,12 +40,17 @@ function handleEvent (cmd) {
   if (cmd === '--squirrel-uninstall') {
     // App was just uninstalled. Undo anything we did in the --squirrel-install and
     // --squirrel-updated handlers
-    removeShortcuts(function () {
-      app.quit()
-    })
 
     // Uninstall .torrent file and magnet link handlers
     handlers.uninstall()
+
+    // Remove desktop/start menu shortcuts.
+    // HACK: add a callback to handlers.uninstall() so we can remove this setTimeout
+    setTimeout(function () {
+      removeShortcuts(function () {
+        app.quit()
+      })
+    }, 1000)
 
     return true
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "create-torrent": "^3.22.1",
     "drag-drop": "^2.11.0",
     "electron-localshortcut": "^0.6.0",
-    "electron-prebuilt": "0.37.4",
+    "electron-prebuilt": "0.37.3",
     "hyperx": "^2.0.2",
     "main-loop": "^3.2.0",
     "mkdirp": "^0.5.1",

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -1067,6 +1067,6 @@ function setupCrashReporter () {
   crashReporter.start({
     companyName: config.APP_NAME,
     productName: config.APP_NAME,
-    submitURL: 'https://webtorrent.io/desktop/crash-report'
+    submitURL: config.CRASH_REPORT_URL
   })
 }

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -35,7 +35,9 @@ var Cast = null
 // a renderer process (essentially a Chrome window). We're in the renderer process,
 // and this IPC channel receives from and sends messages to the main process
 var ipcRenderer = electron.ipcRenderer
+
 var clipboard = electron.clipboard
+var crashReporter = electron.crashReporter
 var dialog = remote.require('dialog')
 
 // For easy debugging in Developer Tools
@@ -58,6 +60,9 @@ loadState(init)
  * the dock icon and drag+drop.
  */
 function init () {
+  setupCrashReporter()
+
+  // Push the first page into the location history
   state.location.go({ url: 'home' })
 
   // Lazily load the WebTorrent, Chromecast, and Airplay modules
@@ -1056,4 +1061,12 @@ function playInterfaceSound (name) {
   audio.volume = sound.volume
   audio.src = sound.url
   audio.play()
+}
+
+function setupCrashReporter () {
+  crashReporter.start({
+    companyName: config.APP_NAME,
+    productName: config.APP_NAME,
+    submitURL: 'https://webtorrent.io/desktop/crash-report'
+  })
 }


### PR DESCRIPTION
This helped me to debug why Electron 0.37.4 was crashing. Turns out that 0.37.4 has a broken Buffer implementation and it seem is (accidentally) using a pre-release version of Node 6. Whoops!

In any case, crash reporting is useful. Going to leave this in.

Server-side components to the reporting are in this PR: https://github.com/feross/webtorrent-www/pull/52