### PR TITLE
Enforce minimimum window size when resizing player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix installation bugs with .deb file (Linux)
 - Pause audio reliably when closing the window
+- Enforce minimimum window size when resizing player (for audio-only .mov files, which are 0x0)
 
 ## v0.3.1 - 2016-04-06
 

--- a/config.js
+++ b/config.js
@@ -65,8 +65,11 @@ module.exports = {
   },
 
   WINDOW_ABOUT: 'file://' + path.join(__dirname, 'renderer', 'about.html'),
+  WINDOW_MAIN: 'file://' + path.join(__dirname, 'renderer', 'main.html'),
   WINDOW_WEBTORRENT: 'file://' + path.join(__dirname, 'renderer', 'webtorrent.html'),
-  WINDOW_MAIN: 'file://' + path.join(__dirname, 'renderer', 'main.html')
+
+  WINDOW_MIN_HEIGHT: 38 + (120 * 2), // header height + 2 torrents
+  WINDOW_MIN_WIDTH: 425
 }
 
 function isProduction () {

--- a/main/windows.js
+++ b/main/windows.js
@@ -82,8 +82,8 @@ function createMainWindow () {
     backgroundColor: '#282828',
     darkTheme: true, // Forces dark theme (GTK+3)
     icon: config.APP_ICON + '.png',
-    minWidth: 425,
-    minHeight: 38 + (120 * 2), // header height + 2 torrents
+    minWidth: config.WINDOW_MIN_WIDTH,
+    minHeight: config.WINDOW_MIN_HEIGHT,
     show: false, // Hide window until DOM finishes loading
     title: config.APP_WINDOW_TITLE,
     titleBarStyle: 'hidden-inset', // Hide OS chrome, except traffic light buttons (OS X)

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -951,8 +951,14 @@ function setDimensions (dimensions) {
     Math.min(screenWidth / dimensions.width, 1),
     Math.min(screenHeight / dimensions.height, 1)
   )
-  var width = Math.floor(dimensions.width * scaleFactor)
-  var height = Math.floor(dimensions.height * scaleFactor)
+  var width = Math.max(
+    Math.floor(dimensions.width * scaleFactor),
+    config.WINDOW_MIN_WIDTH
+  )
+  var height = Math.max(
+    Math.floor(dimensions.height * scaleFactor),
+    config.WINDOW_MIN_HEIGHT
+  )
 
   // Center window on screen
   var x = Math.floor((screenWidth - width) / 2)


### PR DESCRIPTION
For audio-only .mov files, which are 0x0.

Closes #340