### PR TITLE
Exit media when user closes window

### DIFF
--- a/main/windows.js
+++ b/main/windows.js
@@ -106,7 +106,7 @@ function createMainWindow () {
   win.on('close', function (e) {
     if (!electron.app.isQuitting) {
       e.preventDefault()
-      win.send('dispatch', 'pause')
+      win.send('dispatch', 'backToList')
       win.hide()
     }
   })

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -216,6 +216,16 @@ function dispatch (action, ...args) {
   if (action === 'setDimensions') {
     setDimensions(args[0] /* dimensions */)
   }
+  if (action === 'backToList') {
+    while (state.location.hasBack()) state.location.back()
+
+    // Work around virtual-dom issue: it doesn't expose its redraw function,
+    // and only redraws on requestAnimationFrame(). That means when the user
+    // closes the window (hide window / minimize to tray) and we want to pause
+    // the video, we update the vdom but it keeps playing until you reopen!
+    var mediaTag = document.querySelector('video,audio')
+    if (mediaTag) mediaTag.pause()
+  }
   if (action === 'back') {
     state.location.back()
   }
@@ -238,13 +248,6 @@ function dispatch (action, ...args) {
   }
   if (action === 'pause') {
     playPause(true)
-
-    // Work around virtual-dom issue: it doesn't expose its redraw function,
-    // and only redraws on requestAnimationFrame(). That means when the user
-    // closes the window (hide window / minimize to tray) and we want to pause
-    // the video, we update the vdom but it keeps playing until you reopen!
-    var mediaTag = document.querySelector('video,audio')
-    if (mediaTag) mediaTag.pause()
   }
   if (action === 'playbackJump') {
     jumpToTime(args[0] /* seconds */)

--- a/renderer/lib/location-history.js
+++ b/renderer/lib/location-history.js
@@ -34,6 +34,9 @@ LocationHistory.prototype.back = function () {
   var page = this._history.pop()
 
   if (page.onbeforeunload) {
+    // TODO: this is buggy. If the user clicks back twice, then those pages
+    // may end up in _forward in the wrong order depending on which onbeforeunload
+    // call finishes first.
     page.onbeforeunload(() => {
       this._forward.push(page)
     })


### PR DESCRIPTION
Before, if you were in the middle of playing a video and closed the window, the app would actually just pause the video and minimize to tray ---- so if you reopen the window a day later, the video is still there!

This fixes that.