### PR TITLE
Create error on zero-byte poster

### DIFF
--- a/renderer/lib/torrent-poster.js
+++ b/renderer/lib/torrent-poster.js
@@ -64,7 +64,7 @@ function torrentPosterFromVideo (file, torrent, cb) {
 
       server.destroy()
 
-      if (buf.length === 0) cb(new Error('Generated poster contains no data'))
+      if (buf.length === 0) return cb(new Error('Generated poster contains no data'))
 
       cb(null, buf, '.jpg')
     }

--- a/renderer/lib/torrent-poster.js
+++ b/renderer/lib/torrent-poster.js
@@ -64,6 +64,8 @@ function torrentPosterFromVideo (file, torrent, cb) {
 
       server.destroy()
 
+      if (buf.length === 0) cb(new Error('Generated poster contains no data'))
+
       cb(null, buf, '.jpg')
     }
   }


### PR DESCRIPTION
Fixes #341 (Thanks @gdelavald!)

When a 0-byte image is retrieved from a video file to be used as a buffer, the function now creates an error. This prevents the application from producing the unexpected behavior of displaying a *black* background, as opposed to the desired blue gradient.

This happens when the video file used is composed of just audio. When the audio waveform poster generation for sound files is implemented, we may want to trigger that instead, but for now this works fine.