### PR TITLE
Fix JS error on app quit

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -87,7 +87,7 @@ function init () {
   var oldEmit = ipcMain.emit
   ipcMain.emit = function (name, e, ...args) {
     // Relay messages between the main window and the WebTorrent hidden window
-    if (name.startsWith('wt-')) {
+    if (name.startsWith('wt-') && !app.isQuitting) {
       if (e.sender.browserWindowOptions.title === 'webtorrent-hidden-window') {
         // Send message to main window
         windows.main.send(name, ...args)

--- a/main/windows.js
+++ b/main/windows.js
@@ -72,6 +72,10 @@ function createWebTorrentHiddenWindow () {
       win.hide()
     }
   })
+
+  win.once('closed', function () {
+    windows.webtorrent = null
+  })
 }
 
 function createMainWindow () {


### PR DESCRIPTION
This was a rare race condition during app shutdown where a 'wt-'
message would be sent from the hidden webtorrent window to the main
window after the main window was already closed.

Fixes #373