### PR TITLE
Copy infoHash on right click Torrent

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -955,7 +955,7 @@ function openTorrentContextMenu (infoHash) {
   }))
 
   menu.append(new MenuItem({
-    label: 'Copy Torrent infoHash',
+    label: 'Copy Torrent infoHash to clipboard',
     click: () => clipboard.writeText(torrentSummary.infoHash)
   }))
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -954,6 +954,11 @@ function openTorrentContextMenu (infoHash) {
     click: () => clipboard.writeText(torrentSummary.magnetURI)
   }))
 
+  menu.append(new MenuItem({
+    label: 'Copy Torrent infoHash',
+    click: () => clipboard.writeText(torrentSummary.infoHash)
+  }))
+
   menu.popup(remote.getCurrentWindow())
 }
 


### PR DESCRIPTION
Add new menu item to directly copy the infoHash of the torrent on right click.
Requested here: https://github.com/feross/webtorrent-desktop/issues/391