### PR TITLE
Simplify play/pause handling

### DIFF
--- a/renderer/lib/cast.js
+++ b/renderer/lib/cast.js
@@ -5,7 +5,8 @@ module.exports = {
   init,
   open,
   close,
-  playPause,
+  play,
+  pause,
   seek,
   setVolume
 }
@@ -81,9 +82,12 @@ function chromecastPlayer (player) {
     })
   }
 
-  function playPause (callback) {
-    if (!state.playing.isPaused) player.pause(callback)
-    else player.play(null, null, callback)
+  function play (callback) {
+    player.play(null, null, callback)
+  }
+
+  function pause (callback) {
+    player.pause(callback)
   }
 
   function stop (callback) {
@@ -113,7 +117,8 @@ function chromecastPlayer (player) {
   return {
     player: player,
     open: open,
-    playPause: playPause,
+    play: play,
+    pause: pause,
     stop: stop,
     status: status,
     seek: seek,
@@ -138,9 +143,12 @@ function airplayPlayer (player) {
     })
   }
 
-  function playPause (callback) {
-    if (!state.playing.isPaused) player.rate(0, callback)
-    else player.rate(1, callback)
+  function play (callback) {
+    player.rate(1, callback)
+  }
+
+  function pause (callback) {
+    player.rate(0, callback)
   }
 
   function stop (callback) {
@@ -172,7 +180,8 @@ function airplayPlayer (player) {
   return {
     player: player,
     open: open,
-    playPause: playPause,
+    play: play,
+    pause: pause,
     stop: stop,
     status: status,
     seek: seek,
@@ -217,9 +226,12 @@ function dlnaPlayer (player) {
     })
   }
 
-  function playPause (callback) {
-    if (!state.playing.isPaused) player.pause(callback)
-    else player.play(null, null, callback)
+  function play (callback) {
+    player.play(null, null, callback)
+  }
+
+  function pause (callback) {
+    player.pause(callback)
   }
 
   function stop (callback) {
@@ -253,7 +265,8 @@ function dlnaPlayer (player) {
   return {
     player: player,
     open: open,
-    playPause: playPause,
+    play: play,
+    pause: pause,
     stop: stop,
     status: status,
     seek: seek,
@@ -317,10 +330,17 @@ function getDevice (location) {
   }
 }
 
-function playPause () {
+function play () {
   var device = getDevice()
   if (device) {
-    device.playPause(castCallback)
+    device.play(castCallback)
+  }
+}
+
+function pause () {
+  var device = getDevice()
+  if (device) {
+    device.pause(castCallback)
   }
 }
 

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -78,8 +78,6 @@ function renderMedia (state) {
       ondblclick=${dispatcher('toggleFullScreen')}
       onloadedmetadata=${onLoadedMetadata}
       onended=${onEnded}
-      onplay=${dispatcher('mediaPlaying')}
-      onpause=${dispatcher('mediaPaused')}
       onstalling=${dispatcher('mediaStalled')}
       onerror=${dispatcher('mediaError')}
       ontimeupdate=${dispatcher('mediaTimeUpdate')}


### PR DESCRIPTION
I found it awkward to listen to the video tags 'playing' and 'paused'
events, when we're controlling the state that defines what state it's
in in the first place.

This commit removes those listeners, in favor of just setting things to
the right state immediately when play(), pause(), or playPause() is
called.

Added play(), pause() methods for clarity.