### PR TITLE
Add Preferences Support

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -116,6 +116,11 @@ function decreasePlaybackRate () {
   }
 }
 
+// Open the preferences window
+function showPreferences () {
+  windows.main.send('dispatch', 'preferences')
+}
+
 function onWindowShow () {
   log('onWindowShow')
   getMenuItem('Full Screen').enabled = true
@@ -269,6 +274,14 @@ function getAppMenuTemplate () {
           label: 'Select All',
           accelerator: 'CmdOrCtrl+A',
           role: 'selectall'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Preferences',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => showPreferences()
         }
       ]
     },
@@ -407,6 +420,14 @@ function getAppMenuTemplate () {
         {
           label: 'About ' + config.APP_NAME,
           role: 'about'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Preferences',
+          accelerator: 'Cmd+,',
+          click: () => showPreferences()
         },
         {
           type: 'separator'

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -912,6 +912,176 @@ video::-webkit-media-text-track-container {
 }
 
 /*
+ * Preferences page, based on Atom settings style
+ */
+
+.preferences {
+  font-size: 12px;
+  line-height: calc(10/7);
+}
+
+.preferences .text {
+  color: #a8a8a8;
+}
+
+.preferences .icon {
+  color: rgba(170, 170, 170, 0.6);
+  font-size: 16px;
+  margin-right: 0.2em;
+}
+
+.preferences .btn {
+  display: inline-block;
+  -webkit-appearance: button;
+  margin: 0;
+  font-weight: normal;
+  text-align: center;
+  vertical-align: middle;
+  cursor: pointer;
+  border-color: #cccccc;
+  border-radius: 3px;
+  color: #9da5b4;
+  text-shadow: none;
+  border: 1px solid #181a1f;
+  background-color: #3d3d3d;
+  white-space: initial;
+  font-size: 0.889em;
+  line-height: 1;
+  padding: 0.5em 0.75em;
+}
+
+.preferences .btn .icon {
+  margin: 0;
+  color: #a8a8a8;
+  cursor: pointer;
+}
+
+.preferences .help .icon {
+  vertical-align: sub;
+}
+
+
+.preferences .preferences-panel .control-group + .control-group {
+  margin-top: 1.5em;
+}
+
+.preferences .section {
+  padding: 20px;
+  border-top: 1px solid #181a1f;
+}
+
+.preferences .section:first {
+  border-top: 0px;
+}
+
+.preferences .section:first-child,
+.preferences .section:last-child {
+  padding: 20px;
+}
+
+.preferences .section.section:empty {
+  padding: 0;
+  border-top: none;
+}
+
+.preferences .section-container {
+  width: 100%;
+  max-width: 800px;
+}
+
+.preferences section .section-heading,
+.preferences .section .section-heading {
+  margin-bottom: 10px;
+  color: #dcdcdc;
+  font-size: 1.75em;
+  font-weight: bold;
+  line-height: 1;
+  -webkit-user-select: none;
+  cursor: default;
+}
+
+.preferences .sub-section-heading.icon:before,
+.preferences .section-heading.icon:before {
+  margin-right: 8px;
+}
+
+.preferences .section-heading-count {
+  margin-left: .5em;
+}
+
+.preferences .section-body {
+  margin-top: 20px;
+}
+
+.preferences .sub-section {
+  margin: 20px 0;
+}
+
+.preferences .sub-section .sub-section-heading {
+  color: #dcdcdc;
+  font-size: 1.4em;
+  font-weight: bold;
+  line-height: 1;
+  -webkit-user-select: none;
+}
+
+.preferences .preferences-panel label {
+  color: #a8a8a8;
+}
+
+.preferences .preferences-panel .control-group + .control-group {
+  margin-top: 1.5em;
+}
+
+.preferences .preferences-panel .control-group .editor-container {
+  margin: 0;
+}
+
+.preferences .preference-title {
+  font-size: 1.2em;
+  -webkit-user-select: none;
+  display: inline-block;
+}
+
+.preferences .preference-description {
+    color: rgba(170, 170, 170, 0.6);
+    -webkit-user-select: none;
+    cursor: default;
+}
+
+.preferences input {
+  font-size: 1.1em;
+  line-height: 1.15em;
+  max-height: none;
+  width: 100%;
+  padding-left: 0.5em;
+  border-radius: 3px;
+  color: #a8a8a8;
+  border: 1px solid #181a1f;
+  background-color: #1b1d23;
+}
+
+.preferences input::-webkit-input-placeholder {
+  color: rgba(170, 170, 170, 0.6);
+}
+
+.preferences .control-group input {
+  margin-top: 0.2em;
+}
+
+.preferences .control-group input.file-picker-text {
+  width: calc(100% - 40px);
+}
+
+.preferences .control-group .checkbox .icon {
+  font-size: 1.5em;
+  margin: 0;
+  vertical-align: text-bottom;;
+  cursor: pointer;
+}
+
+
+/*
  * MEDIA OVERLAY / AUDIO DETAILS
  */
 

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -266,9 +266,11 @@ function getDefaultSavedState () {
         ]
       }
     ],
-    downloadPath: config.IS_PORTABLE
-      ? path.join(config.CONFIG_PATH, 'Downloads')
-      : remote.app.getPath('downloads')
+    prefs: {
+      downloadPath: config.IS_PORTABLE
+        ? path.join(config.CONFIG_PATH, 'Downloads')
+        : remote.app.getPath('downloads')
+    }
   }
 }
 

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -8,7 +8,8 @@ var Header = require('./header')
 var Views = {
   'home': require('./torrent-list'),
   'player': require('./player'),
-  'create-torrent': require('./create-torrent-page')
+  'create-torrent': require('./create-torrent-page'),
+  'preferences': require('./preferences')
 }
 var Modals = {
   'open-torrent-address-modal': require('./open-torrent-address-modal'),

--- a/renderer/views/header.js
+++ b/renderer/views/header.js
@@ -37,7 +37,7 @@ function Header (state) {
   }
 
   function getAddButton () {
-    if (state.location.url() !== 'player') {
+    if (state.location.url() === 'home') {
       return hx`
         <i
           class='icon add'

--- a/renderer/views/preferences.js
+++ b/renderer/views/preferences.js
@@ -1,0 +1,155 @@
+module.exports = Preferences
+
+var fs = require('fs-extra')
+var h = require('virtual-dom/h')
+var hyperx = require('hyperx')
+var hx = hyperx(h)
+var {dispatch} = require('../lib/dispatcher')
+
+var remote = require('electron').remote
+var dialog = remote.dialog
+
+var prefState
+
+function Preferences (state) {
+  prefState = state.unsaved.prefs
+  var definitions = getPreferenceDefinitions()
+  var sections = []
+
+  definitions.forEach(function (sectionDefinition) {
+    sections.push(renderSection(sectionDefinition))
+  })
+
+  return hx`
+    <div class='preferences'>
+      ${sections}
+    </div>
+  `
+}
+
+function renderSection (definition) {
+  var controls = []
+
+  definition.controls.forEach(function (controlDefinition) {
+    controls.push(controlDefinition.renderer(controlDefinition))
+  })
+
+  return hx`
+    <section class='section preferences-panel'>
+      <div class='section-container'>
+        <div class='section-heading'><i.icon>${definition.icon}</i>${definition.title}</div>
+          <div class='help text'><i.icon>help_outline</i>${definition.description}</div>
+          <div class='section-body'>
+          ${controls}
+          </div>
+      </div>
+    </section>
+  `
+}
+
+function renderFileSelector (definition) {
+  var value = getStateValue(definition.property)
+  return hx`
+    <div class='control-group'>
+      <div class='controls'>
+        <label class='control-label'>
+          <div class='preference-title'>${definition.label}</div>
+          <div class='preference-description'>${definition.description}</div>
+        </label>
+        <div class='controls'>
+          <input type='text' class='file-picker-text'
+            id=${definition.property} placeholder=${definition.placeholder}
+            readonly='readonly'
+            value=${value}/>
+          <button class='btn' onclick=${filePickerHandler}><i.icon>folder_open</i></button>
+        </div>
+      </div>
+    </div>
+  `
+  function filePickerHandler () {
+    dialog.showOpenDialog(remote.getCurrentWindow(), definition.options, function (filenames) {
+      if (!Array.isArray(filenames)) return
+      if (!definition.validator || definition.validator(filenames[0])) {
+        setStateValue(definition.property, filenames[0])
+      }
+    })
+  }
+}
+
+/*
+function renderCheckbox (definition) {
+  var checked = getStateValue(definition.property)
+  var checkbox = checked ? 'check_box' : 'check_box_outline_blank'
+  return hx`
+    <div class='control-group'>
+      <div class='controls'>
+        <div class='checkbox'>
+          <label class='control-label'>
+            <i.icon onclick=${checkboxHandler}>${checkbox}</i>
+            <div class='preference-title' onclick=${checkboxHandler}>${definition.label}</div>
+          </label>
+          <div class='preference-description'>${definition.description}</div>
+        </div>
+      </div>
+    </div>
+  `
+  function checkboxHandler (e) {
+    setStateValue(definition.property, !getStateValue(definition.property))
+  }
+}
+*/
+
+function getPreferenceDefinitions () {
+  return [
+    {
+      title: 'General',
+      description: 'These are WebTorrent Desktop main preferences. Will put a very long text to check if it overflows correctly.',
+      icon: 'settings',
+      controls: [
+        {
+          label: 'Download Path',
+          description: 'Directory where the files will be stored. Please, check if it has enough space!',
+          property: 'downloadPath',
+          renderer: renderFileSelector,
+          placeholder: 'Your downloads directory ie: $HOME/Downloads',
+          options: {
+            title: 'Select download directory.',
+            properties: [ 'openDirectory' ]
+          },
+          validator: function (value) {
+            return fs.existsSync(value)
+          }
+        }
+      ]
+    }/*,
+    {
+      title: 'Interface',
+      description: 'Here you can change the way the application looks and beahaves.',
+      icon: 'view_compact',
+      controls: [
+        {
+          label: 'Disable Tray',
+          description: 'This option gives you the chance to quit immediately and don\'t send the application to background when you close it.',
+          property: 'interface.disableTray',
+          renderer: renderCheckbox
+        }
+      ]
+    }*/
+  ]
+}
+
+function getStateValue (property) {
+  var path = property.split('.')
+  var key = prefState
+  for (var i = 0; i < path.length - 1; i++) {
+    if (typeof key[path[i]] === 'undefined') {
+      return ''
+    }
+    key = key[path[i]]
+  }
+  return key[path[i]]
+}
+
+function setStateValue (property, value) {
+  dispatch('updatePreferences', property, value)
+}

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -142,7 +142,8 @@ function TorrentList (state) {
     // of the play button, unless already showing a spinner there:
     var positionElem
     var willShowSpinner = torrentSummary.playStatus === 'requested'
-    var defaultFile = torrentSummary.files[torrentSummary.defaultPlayFileIndex]
+    var defaultFile = torrentSummary.files &&
+      torrentSummary.files[torrentSummary.defaultPlayFileIndex]
     if (defaultFile && defaultFile.currentTime && !willShowSpinner) {
       var fraction = defaultFile.currentTime / defaultFile.duration
       positionElem = renderRadialProgressBar(fraction, 'radial-progress-large')


### PR DESCRIPTION
I took what @ChrisMorrisOrg started, get some feedback from #62 and this is what you get.

Its not as clean as i want, but is what i get.

Feel free to comment.

The whole idea is to implement a preference section with reusable components (file selector, text, checkbox) and pass parameters to them.

The only active right now is Download Path (help text needs rewording)

![image](https://cloud.githubusercontent.com/assets/6145761/14653136/fc7145f2-064d-11e6-8e34-cba3100674bd.png)

Also, commented is a checkbox preference (Tray disable) which is not working, but you can comment out and see how the pref is saved.

![image](https://cloud.githubusercontent.com/assets/6145761/14653105/db65635c-064d-11e6-9eb2-9bab3a805892.png)

You can also see how a section will be displayed

@dcposch @feross feel free to use the branch to make the change you want.