### PR TITLE
Show an error when adding an invalid magnet link

### DIFF
--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -68,10 +68,15 @@ function init () {
 // See https://github.com/feross/webtorrent/blob/master/docs/api.md#clientaddtorrentid-opts-function-ontorrent-torrent-
 function startTorrenting (torrentKey, torrentID, path, fileModtimes) {
   console.log('starting torrent %s: %s', torrentKey, torrentID)
-  var torrent = client.add(torrentID, {
-    path: path,
-    fileModtimes: fileModtimes
-  })
+  var torrent
+  try {
+    torrent = client.add(torrentID, {
+      path: path,
+      fileModtimes: fileModtimes
+    })
+  } catch (err) {
+    return ipc.send('wt-error', torrentKey, err.message)
+  }
   torrent.key = torrentKey
   addTorrentEvents(torrent)
   return torrent


### PR DESCRIPTION
Fixes #386

**When pasting an invalid magnet link**

Before: nothing happens, no indication about what went wrong

After:
![image](https://cloud.githubusercontent.com/assets/169280/14662381/629cd7da-066a-11e6-80cd-6e31c3a62dfc.png)
