### PR TITLE
Show an error when adding a dupe torrent

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -717,7 +717,7 @@ function torrentError (torrentKey, message) {
 
   // TODO: WebTorrent should have semantic errors
   if (message.startsWith('There is already a swarm')) {
-    onError(new Error('Couldn\'t add duplicate torrent'))
+    onError(new Error('Can\'t add duplicate torrent'))
   } else if (!torrentSummary) {
     onError(message)
   } else {

--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -77,6 +77,12 @@ function startTorrenting (torrentKey, torrentID, path, fileModtimes) {
   } catch (err) {
     return ipc.send('wt-error', torrentKey, err.message)
   }
+  // If we add a duplicate magnet URI or infohash, WebTorrent returns the
+  // existing torrent object! (If we add a duplicate torrent file, it creates a
+  // new torrent object and raises an error later.) Workaround:
+  if (torrent.key) {
+    return ipc.send('wt-error', torrentKey, 'Can\'t add duplicate torrent')
+  }
   torrent.key = torrentKey
   addTorrentEvents(torrent)
   return torrent


### PR DESCRIPTION
This works around a WebTorrent bug where calling client.add(torrentFilePath) to add a duplicate torrent -- in other words, one whose infoHash we're already torrenting -- creates a new torrent object and later throws an error. Inconsistently, calling client.add(magnetURI) or client.add(infoHash) to add a duplicate torrent returns the existing torrent object that we're already torrenting and doesn't throw an error.

This also fixes a prety nasty bug where pasting a dupe magnet link changed the torrentKey of an existing torrent, breaking the communication between the main and WebTorrent windows

Fixes #364