### PR TITLE
Use airplayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/feross/webtorrent-desktop/issues"
   },
   "dependencies": {
-    "airplay-js": "guerrerocarlos/node-airplay-js",
+    "airplayer": "^2.0.0",
     "application-config": "^0.2.1",
     "bitfield": "^1.0.2",
     "chromecasts": "^1.8.0",

--- a/renderer/lib/cast.js
+++ b/renderer/lib/cast.js
@@ -12,7 +12,7 @@ module.exports = {
   setRate
 }
 
-var airplay = require('airplay-js')
+var airplayer = require('airplayer')()
 var chromecasts = require('chromecasts')()
 var dlnacasts = require('dlnacasts')()
 
@@ -41,10 +41,9 @@ function init (appState, callback) {
     state.devices.dlna = dlnaPlayer(player)
   })
 
-  var browser = airplay.createBrowser()
-  browser.on('deviceOn', function (player) {
+  airplayer.on('update', function (player) {
     state.devices.airplay = airplayPlayer(player)
-  }).start()
+  })
 }
 
 // chromecast player implementation
@@ -130,12 +129,12 @@ function chromecastPlayer (player) {
 // airplay player implementation
 function airplayPlayer (player) {
   function open () {
-    player.play(state.server.networkURL, 0, function (res) {
-      if (res.statusCode !== 200) {
+    player.play(state.server.networkURL, function (err, res) {
+      if (err) {
         state.playing.location = 'local'
         state.errors.push({
           time: new Date().getTime(),
-          message: 'Could not connect to AirPlay.'
+          message: 'Could not connect to AirPlay. ' + err.message
         })
       } else {
         state.playing.location = 'airplay'
@@ -145,11 +144,11 @@ function airplayPlayer (player) {
   }
 
   function play (callback) {
-    player.rate(1, callback)
+    player.resume(callback)
   }
 
   function pause (callback) {
-    player.rate(0, callback)
+    player.pause(callback)
   }
 
   function stop (callback) {
@@ -157,13 +156,21 @@ function airplayPlayer (player) {
   }
 
   function status () {
-    player.status(function (status) {
-      state.playing.isPaused = status.rate === 0
-      state.playing.currentTime = status.position
-      // TODO: get airplay volume, implementation needed. meanwhile set value in setVolume
-      // According to docs is in [-30 - 0] (db) range
-      // should be converted to [0 - 1] using (val / 30 + 1)
-      update()
+    player.playbackInfo(function (err, res, status) {
+      if (err) {
+        state.playing.location = 'local'
+        state.errors.push({
+          time: new Date().getTime(),
+          message: 'Could not connect to AirPlay. ' + err.message
+        })
+      } else {
+        state.playing.isPaused = status.rate === 0
+        state.playing.currentTime = status.position
+        // TODO: get airplay volume, implementation needed. meanwhile set value in setVolume
+        // According to docs is in [-30 - 0] (db) range
+        // should be converted to [0 - 1] using (val / 30 + 1)
+        update()
+      }
     })
   }
 

--- a/renderer/lib/cast.js
+++ b/renderer/lib/cast.js
@@ -166,9 +166,6 @@ function airplayPlayer (player) {
       } else {
         state.playing.isPaused = status.rate === 0
         state.playing.currentTime = status.position
-        // TODO: get airplay volume, implementation needed. meanwhile set value in setVolume
-        // According to docs is in [-30 - 0] (db) range
-        // should be converted to [0 - 1] using (val / 30 + 1)
         update()
       }
     })
@@ -179,10 +176,9 @@ function airplayPlayer (player) {
   }
 
   function volume (volume, callback) {
-    // TODO remove line below once we can fetch the information in status update
+    // AirPlay doesn't support volume
+    // TODO: We should just disable the volume slider
     state.playing.volume = volume
-    volume = (volume - 1) * 30
-    player.volume(volume, callback)
   }
 
   return {

--- a/renderer/lib/cast.js
+++ b/renderer/lib/cast.js
@@ -128,6 +128,24 @@ function chromecastPlayer (player) {
 
 // airplay player implementation
 function airplayPlayer (player) {
+  function addEvents () {
+    player.on('event', function (event) {
+      switch (event.state) {
+        case 'loading':
+          break
+        case 'playing':
+          state.playing.isPaused = false
+          break
+        case 'paused':
+          state.playing.isPaused = true
+          break
+        case 'stopped':
+          break
+      }
+      update()
+    })
+  }
+
   function open () {
     player.play(state.server.networkURL, function (err, res) {
       if (err) {
@@ -180,6 +198,8 @@ function airplayPlayer (player) {
     // TODO: We should just disable the volume slider
     state.playing.volume = volume
   }
+
+  addEvents()
 
   return {
     player: player,


### PR DESCRIPTION
This PR is currently WIP and meant as a way of tracking the progress of improving the AirPlay support.

This PR uses the [airplayer](https://github.com/watson/airplayer) module instead of [airplay-js](https://github.com/guerrerocarlos/node-airplay-js).

As far as I can see, the main feature differences between the two modules currently are:

- airplay-js serves the video using HLS, airplayer just streams the video using HTTPS range requests
- airplay-js supports using ffmpeg (if present on the OS) to transpile and cut up the video into smaller pieces to be served as an HLS playlist. Airplayer does not use ffmpeg, so does not support transpiring, but will therefore use significant less CPU for videos that does not need to be transpiled
- airplay-js supports subtitles if ffmpeg is used
- airplayer does not write anything to stdout or stderr

Thoughts and feedback much appreciated 😃 

## Todo

- [x] ~~support~~ mock volume
- [x] update `status` function to new API
- [x] test this on a Apple TV pre 4th gen
- [x] test this on a 4th gen Apple TV
- [x] subscribe to `events`