### PR TITLE
[WIP] Add "Open folder" context menu

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -38,6 +38,7 @@ var dialog = electron.remote.dialog
 var Menu = electron.remote.Menu
 var MenuItem = electron.remote.MenuItem
 var remote = electron.remote
+var shell = electron.shell
 
 // This dependency is the slowest-loading, so we lazy load it
 var Cast = null
@@ -1002,6 +1003,11 @@ function openTorrentContextMenu (infoHash) {
   var torrentSummary = getTorrentSummary(infoHash)
   var menu = new Menu()
   menu.append(new MenuItem({
+    label: 'Go to folder',
+    click: () => openDownloadFolder(torrentSummary)
+  }))
+
+  menu.append(new MenuItem({
     label: 'Save Torrent File As...',
     click: () => saveTorrentFileAs(torrentSummary)
   }))
@@ -1017,6 +1023,12 @@ function openTorrentContextMenu (infoHash) {
   }))
 
   menu.popup(remote.getCurrentWindow())
+}
+
+function openDownloadFolder (torrentSummary) {
+  var folder = path.parse(torrentSummary.name).name
+  var fullPath = path.join(torrentSummary.path, folder)
+  shell.showItemInFolder(fullPath)
 }
 
 function saveTorrentFileAs (torrentSummary) {


### PR DESCRIPTION
Add "Go to folder" menu item in the torrent context menu to open the folder containing the torrent:

![screen shot 2016-05-07 at 21 28 43](https://cloud.githubusercontent.com/assets/10602/15094119/ee522f58-149a-11e6-87cd-5bd5d69573bb.png)

**Questions:**
- [ ] I could rewrite this to use `ipcRenderer.send('showItemInFolder', folderPath)` if you like?
- [ ] Is "Go to folder" the best title? Please let me know if I should change it or if the casing should be different

**To do:**
- [ ] If the torrent is just a single file, open the OS finder window and select the file
- [ ] If the torrent contains multiple files, open the enclosing folder using the OS finder window
- [ ] Only show context menu, if the torrent have been created on the filesystem

**Nice to have:**
- [ ] If the torrent contains multiple files, allow the user to right click an individual file and have the OS finder window highlight that particular file (I'm not sure if this is possible without major refactoring)