### PR TITLE
Add "Show in Folder" to context menu

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -70,8 +70,13 @@ function init () {
   })
 
   ipcMain.on('openItem', function (e, path) {
-    log('opening file or folder: ' + path)
+    log('open item: ' + path)
     electron.shell.openItem(path)
+  })
+
+  ipcMain.on('showItemInFolder', function (e, path) {
+    log('show item in folder: ' + path)
+    electron.shell.showItemInFolder(path)
   })
 
   ipcMain.on('blockPowerSave', blockPowerSave)

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -167,7 +167,6 @@ function TorrentList (state) {
 
   // Show files, per-file download status and play buttons, and so on
   function renderTorrentDetails (torrentSummary) {
-    var infoHash = torrentSummary.infoHash
     var filesElement
     if (!torrentSummary.files) {
       // We don't know what files this torrent contains
@@ -182,10 +181,6 @@ function TorrentList (state) {
       filesElement = hx`
         <div class='files'>
           <strong>Files</strong>
-          <span class='open-folder'
-            onclick=${dispatcher('openFolder', infoHash)}>
-            Open folder
-          </span>
           <table>
             ${fileRows}
           </table>


### PR DESCRIPTION
Based on @watson's PR #463.

Differences:

- Remove the "Open Folder" link from expanded torrent view.
- Use showItemInFolder instead of openItem electron API
- Add a separator
- Use IPC to invoke electron.shell.showItemInFolder from main process