### PR TITLE
add `npm run open-config` to open config file quickly

### DIFF
--- a/bin/open-config.js
+++ b/bin/open-config.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var config = require('../config')
+var open = require('open')
+var path = require('path')
+
+var configPath = path.join(config.CONFIG_PATH, 'config.json')
+open(configPath)

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nobin-debian-installer": "^0.0.9",
+    "open": "0.0.5",
     "plist": "^1.2.0",
     "rimraf": "^2.5.2",
     "run-series": "^1.1.4",
@@ -76,6 +77,7 @@
   },
   "scripts": {
     "clean": "node ./bin/clean.js",
+    "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
     "start": "electron .",
     "test": "standard && ./bin/check-deps.js",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
     "desktop",
     "electron",
     "electron-app",
+    "hybrid webtorrent client",
+    "mad science",
+    "torrent client",
+    "torrent",
     "webtorrent"
   ],
   "license": "MIT",

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -26,7 +26,7 @@ var TorrentSummary = require('./lib/torrent-summary')
 var {setDispatch} = require('./lib/dispatcher')
 setDispatch(dispatch)
 
-appConfig.filePath = config.CONFIG_PATH + path.sep + 'config.json'
+appConfig.filePath = path.join(config.CONFIG_PATH, 'config.json')
 
 // Electron apps have two processes: a main process (node) runs first and starts
 // a renderer process (essentially a Chrome window). We're in the renderer process,


### PR DESCRIPTION
Running `npm run open-config` will open the `~/Library/Application Support/WebTorrent/config.json` file on OS X, etc. etc. on other OSes.