### PR TITLE
Fix torrentPath migration

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -126,10 +126,19 @@ function cleanUpConfig () {
     // Migration: replace torrentPath with torrentFileName
     var src, dst
     if (ts.torrentPath) {
+      // There are a number of cases to handle here:
+      // * Originally we used absolute paths
+      // * Then, relative paths for the default torrents, eg '../static/sintel.torrent'
+      // * Then, paths computed at runtime for default torrents, eg 'sintel.torrent'
+      // * Finally, now we're getting rid of torrentPath altogether
       console.log('migration: replacing torrentPath %s', ts.torrentPath)
-      src = path.isAbsolute(ts.torrentPath)
-        ? ts.torrentPath
-        : path.join(config.STATIC_PATH, ts.torrentPath)
+      if (path.isAbsolute(ts.torrentPath)) {
+        src = ts.torrentPath
+      } else if (ts.torrentPath.startsWith('..')) {
+        src = ts.torrentPath
+      } else {
+        src = path.join(config.STATIC_PATH, ts.torrentPath)
+      }
       dst = path.join(config.CONFIG_TORRENT_PATH, infoHash + '.torrent')
       // Synchronous FS calls aren't ideal, but probably OK in a migration
       // that only runs once


### PR DESCRIPTION
Fixes #448 

**We should test this on Windows before merging.**

**Test plan:**
1. Delete config.json
2. Install the current released version
4. Run, add a torrent, then quit
5. Run from this branch. Both default torrents and the new one you added should still work
6. Repeat 1-5 on Windows and on posix (Mac or Linux)

