### PR TITLE
Allow selecting individual files to torrent

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -113,6 +113,10 @@ table {
   opacity: 0.3;
 }
 
+.clickable {
+  cursor: pointer;
+}
+
 .float-right {
   float: right;
 }
@@ -597,7 +601,7 @@ body.drag .app::after {
 }
 
 .torrent-details {
-  padding: 8em 20px 20px 20px;
+  padding: 8em 12px 20px 20px;
 }
 
 .torrent-details table {
@@ -611,6 +615,10 @@ body.drag .app::after {
   height: 28px;
 }
 
+.torrent-details td {
+  vertical-align: center;
+}
+
 .torrent-details tr:hover {
   background-color: rgba(200, 200, 200, 0.3);
 }
@@ -621,14 +629,14 @@ body.drag .app::after {
   vertical-align: bottom;
 }
 
-.torrent-details td.col-icon {
-  width: 2em;
-}
-
-.torrent-details td.col-icon .icon {
+.torrent-details td .icon {
   font-size: 18px;
   position: relative;
   top: 3px;
+}
+
+.torrent-details td.col-icon {
+  width: 2em;
 }
 
 .torrent-details td.col-name {
@@ -643,6 +651,11 @@ body.drag .app::after {
 
 .torrent-details td.col-size {
   width: 4em;
+  text-align: right;
+}
+
+.torrent-details td.col-select {
+  width: 2em;
   text-align: right;
 }
 

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -208,7 +208,8 @@ function TorrentList (state) {
   // Show a single torrentSummary file in the details view for a single torrent
   function renderFileRow (torrentSummary, file, index) {
     // First, find out how much of the file we've downloaded
-    var isDone = false
+    var isSelected = torrentSummary.selections[index] // Are we even torrenting it?
+    var isDone = false // Are we finished torrenting it?
     var progress = ''
     if (torrentSummary.progress && torrentSummary.progress.files) {
       var fileProg = torrentSummary.progress.files[index]
@@ -217,26 +218,38 @@ function TorrentList (state) {
     }
 
     // Second, render the file as a table row
+    var isPlayable = TorrentPlayer.isPlayable(file)
     var infoHash = torrentSummary.infoHash
     var icon
-    var rowClass = ''
     var handleClick
-    if (TorrentPlayer.isPlayable(file)) {
+    if (isPlayable) {
       icon = 'play_arrow' /* playable? add option to play */
       handleClick = dispatcher('play', infoHash, index)
     } else {
       icon = 'description' /* file icon, opens in OS default app */
-      rowClass = isDone ? '' : 'disabled'
       handleClick = dispatcher('openFile', infoHash, index)
     }
+    var rowClass = 'clickable'
+    if (!isSelected) rowClass = 'disabled' // File deselected, not being torrented
+    if (!isDone && !isPlayable) rowClass = 'disabled' // Can't open yet, can't stream
     return hx`
-      <tr onclick=${handleClick} class='${rowClass}'>
-        <td class='col-icon'>
+      <tr>
+        <td class='col-icon ${rowClass}' onclick=${handleClick}>
           <i class='icon'>${icon}</i>
         </td>
-        <td class='col-name'>${file.name}</td>
-        <td class='col-progress'>${progress}</td>
-        <td class='col-size'>${prettyBytes(file.length)}</td>
+        <td class='col-name ${rowClass}' onclick=${handleClick}>
+          ${file.name}
+        </td>
+        <td class='col-progress ${rowClass}' onclick=${handleClick}>
+          ${isSelected ? progress : ''}
+        </td>
+        <td class='col-size ${rowClass}' onclick=${handleClick}>
+          ${prettyBytes(file.length)}
+        </td>
+        <td class='col-select'
+            onclick=${dispatcher('toggleTorrentFile', infoHash, index)}>
+          <i class='icon'>${isSelected ? 'close' : 'add'}</i>
+        </td>
       </tr>
     `
   }


### PR DESCRIPTION
Saves bandwidth and disk space when a torrent contains extra files you don't need

Fixes #360 

![image](https://cloud.githubusercontent.com/assets/169280/15181322/7a3917b4-173b-11e6-819f-f6c6b749e7de.png)
