### PR TITLE
Avoid TypeError out of OS X

### DIFF
--- a/main/windows.js
+++ b/main/windows.js
@@ -100,7 +100,9 @@ function createMainWindow () {
     height: HEADER_HEIGHT + (TORRENT_HEIGHT * 5) // header height + 4 torrents
   })
   win.loadURL(config.WINDOW_MAIN)
-  win.setSheetOffset(HEADER_HEIGHT)
+  if (process.platform === 'darwin') {
+    win.setSheetOffset(HEADER_HEIGHT)
+  }
 
   win.webContents.on('dom-ready', function () {
     menu.onToggleFullScreen()


### PR DESCRIPTION
win.setSheetOffset at main/window.js is undefined on non OS X environments. 
Just guarding against TypeError