### PR TITLE
Fix duplicate torrent handling

### DIFF
--- a/crash-reporter.js
+++ b/crash-reporter.js
@@ -11,5 +11,4 @@ function init () {
     productName: config.APP_NAME,
     submitURL: config.CRASH_REPORT_URL
   })
-  console.log('crash reporter started')
 }

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-console.time('init')
 require('./main')

--- a/main/index.js
+++ b/main/index.js
@@ -1,3 +1,5 @@
+console.time('init')
+
 var electron = require('electron')
 
 var app = electron.app
@@ -67,6 +69,7 @@ function init () {
   app.on('ipcReady', function () {
     log('Command line args:', argv)
     processArgv(argv)
+    console.timeEnd('init')
   })
 
   app.on('before-quit', function (e) {

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -25,10 +25,9 @@ var vlcProcess
 
 function init () {
   ipcMain.on('ipcReady', function (e) {
+    windows.main.show()
     app.ipcReady = true
     app.emit('ipcReady')
-    windows.main.show()
-    console.timeEnd('init')
   })
 
   ipcMain.on('ipcReadyWebTorrent', function (e) {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -724,16 +724,16 @@ function torrentWarning (torrentKey, message) {
 }
 
 function torrentError (torrentKey, message) {
-  var torrentSummary = getTorrentSummary(torrentKey)
+  // TODO: WebTorrent needs semantic errors
+  if (message.startsWith('Cannot add duplicate torrent')) {
+    // Remove infohash from the message
+    message = 'Cannot add duplicate torrent'
+  }
+  onError(message)
 
-  // TODO: WebTorrent should have semantic errors
-  if (message.startsWith('There is already a swarm')) {
-    onError(new Error('Can\'t add duplicate torrent'))
-  } else if (!torrentSummary) {
-    onError(message)
-  } else {
-    console.log('error, stopping torrent %s (%s):\n\t%o',
-      torrentSummary.name, torrentSummary.infoHash, message)
+  var torrentSummary = getTorrentSummary(torrentKey)
+  if (torrentSummary) {
+    console.log('Pausing torrent %s due to error: %s', torrentSummary.infoHash, message)
     torrentSummary.status = 'paused'
     update()
   }

--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -68,23 +68,14 @@ function init () {
 // See https://github.com/feross/webtorrent/blob/master/docs/api.md#clientaddtorrentid-opts-function-ontorrent-torrent-
 function startTorrenting (torrentKey, torrentID, path, fileModtimes) {
   console.log('starting torrent %s: %s', torrentKey, torrentID)
-  var torrent
-  try {
-    torrent = client.add(torrentID, {
-      path: path,
-      fileModtimes: fileModtimes
-    })
-  } catch (err) {
-    return ipc.send('wt-error', torrentKey, err.message)
-  }
-  // If we add a duplicate magnet URI or infohash, WebTorrent returns the
-  // existing torrent object! (If we add a duplicate torrent file, it creates a
-  // new torrent object and raises an error later.) Workaround:
-  if (torrent.key) {
-    return ipc.send('wt-error', torrentKey, 'Can\'t add duplicate torrent')
-  }
+
+  var torrent = client.add(torrentID, {
+    path: path,
+    fileModtimes: fileModtimes
+  })
   torrent.key = torrentKey
   addTorrentEvents(torrent)
+
   return torrent
 }
 


### PR DESCRIPTION
WebTorrent 0.91 changed how duplicate torrents are handled, which broke
handling in WebTorrent Desktop.

After this PR:

- No more try-catch on client.add -- this method has never thrown errors.

- No check for duplicate torrent.key value since client.add no longer
returns the same torrent object when adding a duplicate torrent. It
emits 'error' instead, and that case is already handled :)