### PR TITLE
UI tweaks: Reduce font size, list item height, single torrent status line

### DIFF
--- a/main/windows.js
+++ b/main/windows.js
@@ -97,7 +97,7 @@ function createMainWindow () {
     titleBarStyle: 'hidden-inset', // Hide OS chrome, except traffic light buttons (OS X)
     useContentSize: true, // Specify web page size without OS chrome
     width: 500,
-    height: HEADER_HEIGHT + (TORRENT_HEIGHT * 5) // header height + 4 torrents
+    height: HEADER_HEIGHT + (TORRENT_HEIGHT * 6) // header height + 5 torrents
   })
   win.loadURL(config.WINDOW_MAIN)
   win.setSheetOffset(HEADER_HEIGHT)

--- a/main/windows.js
+++ b/main/windows.js
@@ -80,7 +80,7 @@ function createWebTorrentHiddenWindow () {
 }
 
 var HEADER_HEIGHT = 37
-var TORRENT_HEIGHT = 120
+var TORRENT_HEIGHT = 110
 
 function createMainWindow () {
   if (windows.main) {

--- a/main/windows.js
+++ b/main/windows.js
@@ -80,7 +80,7 @@ function createWebTorrentHiddenWindow () {
 }
 
 var HEADER_HEIGHT = 37
-var TORRENT_HEIGHT = 110
+var TORRENT_HEIGHT = 100
 
 function createMainWindow () {
   if (windows.main) {

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -276,7 +276,6 @@ table {
 }
 
 .modal label {
-  font-size: 16px;
   font-weight: bold;
 }
 
@@ -434,7 +433,7 @@ input {
 
 .torrent,
 .torrent-placeholder {
-  height: 120px;
+  height: 110px;
 }
 
 .torrent:not(:last-child) {
@@ -464,7 +463,7 @@ input {
 
 .torrent .buttons {
   position: absolute;
-  top: 25px;
+  top: 34px;
   right: 10px;
   align-items: center;
   display: none;
@@ -547,15 +546,15 @@ input {
 }
 
 .torrent .name {
-  font-size: 1.5em;
+  font-size: 18px;
   font-weight: bold;
   line-height: 1.5em;
 }
 
 .torrent .status,
 .torrent .status2 {
-  font-size: 1em;
-  line-height: 1.5em;
+/*  font-size: 14px;
+  line-height: 1.5em;*/
 }
 
 /*

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -433,7 +433,7 @@ input {
 
 .torrent,
 .torrent-placeholder {
-  height: 110px;
+  height: 100px;
 }
 
 .torrent:not(:last-child) {
@@ -446,9 +446,9 @@ input {
 
 .torrent .metadata {
   position: absolute;
-  top: 20px;
-  left: 20px;
-  right: 20px;
+  top: 25px;
+  left: 15px;
+  right: 15px;
   width: calc(100% - 40px);
   text-shadow: rgba(0, 0, 0, 0.5) 0 0 4px;
 }
@@ -458,12 +458,15 @@ input {
 }
 
 .torrent .metadata span:not(:last-child)::after {
-  content: ' — ';
+  content: ' • ';
+  opacity: 0.7;
+  padding-left: 4px;
+  padding-right: 4px;
 }
 
 .torrent .buttons {
   position: absolute;
-  top: 34px;
+  top: 29px;
   right: 10px;
   align-items: center;
   display: none;
@@ -549,12 +552,6 @@ input {
   font-size: 18px;
   font-weight: bold;
   line-height: 1.5em;
-}
-
-.torrent .status,
-.torrent .status2 {
-/*  font-size: 14px;
-  line-height: 1.5em;*/
 }
 
 /*

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -71,9 +71,9 @@ function TorrentList (state) {
         <div class='ellipsis'>
           ${renderPercentProgress()}
           ${renderTotalProgress()}
+          ${renderPeers()}
           ${renderDownloadSpeed()}
           ${renderUploadSpeed()}
-          ${renderPeers()}
         </div>
       `)
     }
@@ -95,6 +95,12 @@ function TorrentList (state) {
       }
     }
 
+    function renderPeers () {
+      if (prog.numPeers === 0) return
+      var count = prog.numPeers === 1 ? 'peer' : 'peers'
+      return hx`<span>${prog.numPeers} ${count}</span>`
+    }
+
     function renderDownloadSpeed () {
       if (prog.downloadSpeed === 0) return
       return hx`<span>↓ ${prettyBytes(prog.downloadSpeed)}/s</span>`
@@ -103,12 +109,6 @@ function TorrentList (state) {
     function renderUploadSpeed () {
       if (prog.uploadSpeed === 0) return
       return hx`<span>↑ ${prettyBytes(prog.uploadSpeed)}/s</span>`
-    }
-
-    function renderPeers () {
-      if (prog.numPeers === 0) return
-      var count = prog.numPeers === 1 ? 'peer' : 'peers'
-      return hx`<span>${prog.numPeers} ${count}</span>`
     }
   }
 

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -67,38 +67,48 @@ function TorrentList (state) {
     // If it's downloading/seeding then show progress info
     var prog = torrentSummary.progress
     if (torrentSummary.status !== 'paused' && prog) {
-      var progress = Math.floor(100 * prog.progress)
-      var downloaded = prettyBytes(prog.downloaded)
-      var total = prettyBytes(prog.length || 0)
-      if (downloaded !== total) downloaded += ` / ${total}`
-
       elements.push(hx`
         <div class='ellipsis'>
-          ${getFilesLength()}
-          <span>${getPeers()}</span>
-          <span>↓ ${prettyBytes(prog.downloadSpeed || 0)}/s</span>
-          <span>↑ ${prettyBytes(prog.uploadSpeed || 0)}/s</span>
-        </div>
-      `)
-      elements.push(hx`
-        <div class='ellipsis'>
-          <span class='progress'>${progress}%</span>
-          <span>${downloaded}</span>
+          ${renderPercentProgress()}
+          ${renderTotalProgress()}
+          ${renderDownloadSpeed()}
+          ${renderUploadSpeed()}
+          ${renderPeers()}
         </div>
       `)
     }
 
     return hx`<div class='metadata'>${elements}</div>`
 
-    function getPeers () {
-      var count = prog.numPeers === 1 ? 'peer' : 'peers'
-      return `${prog.numPeers} ${count}`
+    function renderPercentProgress () {
+      var progress = Math.floor(100 * prog.progress)
+      return hx`<span>${progress}%</span>`
     }
 
-    function getFilesLength () {
-      if (torrentSummary.files && torrentSummary.files.length > 1) {
-        return hx`<span class='files'>${torrentSummary.files.length} files</span>`
+    function renderTotalProgress () {
+      var downloaded = prettyBytes(prog.downloaded)
+      var total = prettyBytes(prog.length || 0)
+      if (downloaded === total) {
+        return hx`<span>${downloaded}</span>`
+      } else {
+        return hx`<span>${downloaded} / ${total}</span>`
       }
+    }
+
+    function renderDownloadSpeed () {
+      if (prog.downloadSpeed === 0) return
+      return hx`<span>↓ ${prettyBytes(prog.downloadSpeed)}/s</span>`
+    }
+
+    function renderUploadSpeed () {
+      if (prog.uploadSpeed === 0) return
+      return hx`<span>↑ ${prettyBytes(prog.uploadSpeed)}/s</span>`
+    }
+
+    function renderPeers () {
+      if (prog.numPeers === 0) return
+      var count = prog.numPeers === 1 ? 'peer' : 'peers'
+      return hx`<span>${prog.numPeers} ${count}</span>`
     }
   }
 

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -73,7 +73,7 @@ function TorrentList (state) {
       if (downloaded !== total) downloaded += ` / ${total}`
 
       elements.push(hx`
-        <div class='status ellipsis'>
+        <div class='ellipsis'>
           ${getFilesLength()}
           <span>${getPeers()}</span>
           <span>↓ ${prettyBytes(prog.downloadSpeed || 0)}/s</span>
@@ -81,7 +81,7 @@ function TorrentList (state) {
         </div>
       `)
       elements.push(hx`
-        <div class='status2 ellipsis'>
+        <div class='ellipsis'>
           <span class='progress'>${progress}%</span>
           <span>${downloaded}</span>
         </div>


### PR DESCRIPTION
The goal of this PR is to make the UI more compact. WebTorrent Desktop's UI is currently a lot larger than a lot of the other apps I use on a daily basis. This makes it harder to manage even a moderate number of torrents.

- Reduce torrent list item from 120px to 100px height
- Reduce font sizes (torrent list, modal labels)
- Make default window height big enough to show all torrents

Other UI improvements:

- Vertically center torrent list buttons
- Merge the two torrent status lines onto a single, concise line
  - Hide download speed, upload speed, and number of peers when 0, because that's just noise.
  - Remove number of files, because that information can be found by expanding the torrent.

Before | After
----------|-------
![screen shot 2016-05-12 at 15 40 58](https://cloud.githubusercontent.com/assets/121766/15232805/8e508b38-1858-11e6-929d-ff9e9499a9cc.png) | ![screen shot 2016-05-12 at 15 40 32](https://cloud.githubusercontent.com/assets/121766/15232803/8d4d6d14-1858-11e6-87ae-f8058719d95b.png)

Detailed view:

![screen shot 2016-05-12 at 15 40 32](https://cloud.githubusercontent.com/assets/121766/15232803/8d4d6d14-1858-11e6-87ae-f8058719d95b.png)
