### PR TITLE
Shortcuts improvements

### DIFF
--- a/config.js
+++ b/config.js
@@ -28,7 +28,10 @@ module.exports = {
   CONFIG_TORRENT_PATH: path.join(getConfigPath(), 'Torrents'),
 
   GITHUB_URL: 'https://github.com/feross/webtorrent-desktop',
+  GITHUB_URL_ISSUES: 'https://github.com/feross/webtorrent-desktop/issues',
   GITHUB_URL_RAW: 'https://raw.githubusercontent.com/feross/webtorrent-desktop/master',
+
+  HOME_PAGE_URL: 'https://webtorrent.io',
 
   IS_PORTABLE: isPortable(),
   IS_PRODUCTION: isProduction(),

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -82,12 +82,12 @@ function init () {
 
   ipcMain.on('onPlayerOpen', function () {
     menu.onPlayerOpen()
-    shortcuts.registerPlayerShortcuts()
+    shortcuts.onPlayerOpen()
   })
 
   ipcMain.on('onPlayerClose', function () {
     menu.onPlayerClose()
-    shortcuts.unregisterPlayerShortcuts()
+    shortcuts.onPlayerOpen()
   })
 
   ipcMain.on('focusWindow', function (e, windowName) {

--- a/main/menu.js
+++ b/main/menu.js
@@ -5,6 +5,8 @@ module.exports = {
   onToggleFullScreen,
   onWindowHide,
   onWindowShow,
+
+  // TODO: move these out of menu.js -- they don't belong here
   showOpenSeedFiles,
   showOpenTorrentAddress,
   showOpenTorrentFile,

--- a/main/menu.js
+++ b/main/menu.js
@@ -269,17 +269,6 @@ function getAppMenuTemplate () {
       ]
     },
     {
-      label: 'Window',
-      role: 'window',
-      submenu: [
-        {
-          label: 'Minimize',
-          accelerator: 'CmdOrCtrl+M',
-          role: 'minimize'
-        }
-      ]
-    },
-    {
       label: 'Help',
       role: 'help',
       submenu: [
@@ -303,7 +292,7 @@ function getAppMenuTemplate () {
   ]
 
   if (process.platform === 'darwin') {
-    // WebTorrent menu (OS X)
+    // Add WebTorrent app menu (OS X)
     template.unshift({
       label: config.APP_NAME,
       submenu: [
@@ -347,16 +336,25 @@ function getAppMenuTemplate () {
       ]
     })
 
-    // Window menu (OS X)
-    template[5].submenu.push(
-      {
-        type: 'separator'
-      },
-      {
-        label: 'Bring All to Front',
-        role: 'front'
-      }
-    )
+    // Add Window menu (OS X)
+    template.splice(5, 0, {
+      label: 'Window',
+      role: 'window',
+      submenu: [
+        {
+          label: 'Minimize',
+          accelerator: 'CmdOrCtrl+M',
+          role: 'minimize'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Bring All to Front',
+          role: 'front'
+        }
+      ]
+    })
   }
 
   // In Linux and Windows it is not possible to open both folders and files
@@ -368,7 +366,7 @@ function getAppMenuTemplate () {
     })
 
     // Help menu (Windows, Linux)
-    template[5].submenu.push(
+    template[4].submenu.push(
       {
         type: 'separator'
       },

--- a/main/menu.js
+++ b/main/menu.js
@@ -49,18 +49,6 @@ function toggleFloatOnTop (flag) {
   }
 }
 
-function increaseVolume () {
-  if (windows.main) {
-    windows.main.send('dispatch', 'changeVolume', 0.1)
-  }
-}
-
-function decreaseVolume () {
-  if (windows.main) {
-    windows.main.send('dispatch', 'changeVolume', -0.1)
-  }
-}
-
 function toggleDevTools () {
   log('toggleDevTools')
   if (windows.main) {
@@ -71,6 +59,24 @@ function toggleDevTools () {
 function showWebTorrentWindow () {
   windows.webtorrent.show()
   windows.webtorrent.webContents.openDevTools({ detach: true })
+}
+
+function playPause () {
+  if (windows.main) {
+    windows.main.send('dispatch', 'playPause')
+  }
+}
+
+function increaseVolume () {
+  if (windows.main) {
+    windows.main.send('dispatch', 'changeVolume', 0.1)
+  }
+}
+
+function decreaseVolume () {
+  if (windows.main) {
+    windows.main.send('dispatch', 'changeVolume', -0.1)
+  }
 }
 
 function onWindowShow () {
@@ -86,11 +92,15 @@ function onWindowHide () {
 }
 
 function onPlayerOpen () {
+  log('onPlayerOpen')
+  getMenuItem('Play/Pause').enabled = true
   getMenuItem('Increase Volume').enabled = true
   getMenuItem('Decrease Volume').enabled = true
 }
 
 function onPlayerClose () {
+  log('onPlayerClose')
+  getMenuItem('Play/Pause').enabled = false
   getMenuItem('Increase Volume').enabled = false
   getMenuItem('Decrease Volume').enabled = false
 }
@@ -182,7 +192,9 @@ function getAppMenuTemplate () {
           type: 'separator'
         },
         {
-          label: process.platform === 'windows' ? 'Close' : 'Close Window',
+          label: process.platform === 'windows'
+            ? 'Close'
+            : 'Close Window',
           accelerator: 'CmdOrCtrl+W',
           role: 'close'
         }
@@ -256,6 +268,15 @@ function getAppMenuTemplate () {
     {
       label: 'Playback',
       submenu: [
+        {
+          label: 'Play/Pause',
+          accelerator: 'CmdOrCtrl+P',
+          click: playPause,
+          enabled: false
+        },
+        {
+          type: 'separator'
+        },
         {
           label: 'Increase Volume',
           accelerator: 'CmdOrCtrl+Up',
@@ -378,7 +399,8 @@ function getAppMenuTemplate () {
       }
     )
   }
-  // Add "File > Quit" menu item for Linux distros where the system tray is broken
+  // Add "File > Quit" menu item so Linux distros where the system tray icon is missing
+  // will have a way to quit the app.
   if (process.platform === 'linux') {
     // File menu (Linux)
     template[0].push({

--- a/main/menu.js
+++ b/main/menu.js
@@ -57,6 +57,7 @@ function toggleDevTools () {
 }
 
 function showWebTorrentWindow () {
+  log('showWebTorrentWindow')
   windows.webtorrent.show()
   windows.webtorrent.webContents.openDevTools({ detach: true })
 }

--- a/main/menu.js
+++ b/main/menu.js
@@ -231,21 +231,6 @@ function getAppMenuTemplate () {
           type: 'separator'
         },
         {
-          label: 'Increase Volume',
-          accelerator: 'CmdOrCtrl+Up',
-          click: increaseVolume,
-          enabled: false
-        },
-        {
-          label: 'Decrease Volume',
-          accelerator: 'CmdOrCtrl+Down',
-          click: decreaseVolume,
-          enabled: false
-        },
-        {
-          type: 'separator'
-        },
-        {
           label: 'Developer',
           submenu: [
             {
@@ -263,6 +248,23 @@ function getAppMenuTemplate () {
               click: showWebTorrentWindow
             }
           ]
+        }
+      ]
+    },
+    {
+      label: 'Playback',
+      submenu: [
+        {
+          label: 'Increase Volume',
+          accelerator: 'CmdOrCtrl+Up',
+          click: increaseVolume,
+          enabled: false
+        },
+        {
+          label: 'Decrease Volume',
+          accelerator: 'CmdOrCtrl+Down',
+          click: decreaseVolume,
+          enabled: false
         }
       ]
     },
@@ -346,7 +348,7 @@ function getAppMenuTemplate () {
     })
 
     // Window menu (OS X)
-    template[4].submenu.push(
+    template[5].submenu.push(
       {
         type: 'separator'
       },
@@ -366,7 +368,7 @@ function getAppMenuTemplate () {
     })
 
     // Help menu (Windows, Linux)
-    template[4].submenu.push(
+    template[5].submenu.push(
       {
         type: 'separator'
       },

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -13,17 +13,17 @@ var menu = require('./menu')
 var windows = require('./windows')
 
 function init () {
-  // ⌘+Shift+F is an alternative fullscreen shortcut to the ones defined in menu.js.
-  // Electron does not support multiple accelerators for a single menu item, so this
-  // is registered separately here.
+  // Register alternate shortcuts here. Most shortcuts are registered in menu,js, but Electron does not support multiple shortcuts for a single menu item.
   localShortcut.register('CmdOrCtrl+Shift+F', menu.toggleFullScreen)
+  localShortcut.register('Space', () => windows.main.send('dispatch', 'playPause'))
 }
 
 function onPlayerOpen () {
   // Register special "media key" for play/pause, available on some keyboards
-  globalShortcut.register('MediaPlayPause', function () {
-    windows.main.send('dispatch', 'playPause')
-  })
+  globalShortcut.register(
+    'MediaPlayPause',
+    () => windows.main.send('dispatch', 'playPause')
+  )
 }
 
 function onPlayerClose () {

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -1,7 +1,7 @@
 module.exports = {
   init,
-  registerPlayerShortcuts,
-  unregisterPlayerShortcuts
+  onPlayerClose,
+  onPlayerOpen
 }
 
 var electron = require('electron')
@@ -19,11 +19,13 @@ function init () {
   localShortcut.register('CmdOrCtrl+Shift+F', menu.toggleFullScreen)
 }
 
-function registerPlayerShortcuts () {
-  // Special "media key" for play/pause, available on some keyboards
-  globalShortcut.register('MediaPlayPause', () => windows.main.send('dispatch', 'playPause'))
+function onPlayerOpen () {
+  // Register special "media key" for play/pause, available on some keyboards
+  globalShortcut.register('MediaPlayPause', function () {
+    windows.main.send('dispatch', 'playPause')
+  })
 }
 
-function unregisterPlayerShortcuts () {
+function onPlayerClose () {
   globalShortcut.unregister('MediaPlayPause')
 }

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -13,9 +13,13 @@ var menu = require('./menu')
 var windows = require('./windows')
 
 function init () {
-  // Register alternate shortcuts here. Most shortcuts are registered in menu,js, but Electron does not support multiple shortcuts for a single menu item.
+  // Alternate shortcuts. Most shortcuts are registered in menu,js, but Electron does not
+  // support multiple shortcuts for a single menu item.
   localShortcut.register('CmdOrCtrl+Shift+F', menu.toggleFullScreen)
   localShortcut.register('Space', () => windows.main.send('dispatch', 'playPause'))
+
+  // Hidden shortcuts, i.e. not shown in the menu
+  localShortcut.register('Esc', () => windows.main.send('dispatch', 'escapeBack'))
 }
 
 function onPlayerOpen () {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -378,6 +378,7 @@ function pause () {
 }
 
 function playPause () {
+  if (state.location.current().url !== 'player') return
   if (state.playing.isPaused) {
     play()
   } else {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -1155,8 +1155,6 @@ function onKeyDown (e) {
     } else {
       dispatch('back')
     }
-  } else if (e.which === 32) { /* spacebar pauses or plays the video */
-    dispatch('playPause')
   }
 }
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -96,9 +96,6 @@ function init () {
   // ...same thing if you paste a torrent
   document.addEventListener('paste', onPaste)
 
-  // ...keyboard shortcuts
-  document.addEventListener('keydown', onKeyDown)
-
   // ...focus and blur. Needed to show correct dock icon text ("badge") in OSX
   window.addEventListener('focus', onFocus)
   window.addEventListener('blur', onBlur)
@@ -255,6 +252,15 @@ function dispatch (action, ...args) {
     // the video, we update the vdom but it keeps playing until you reopen!
     var mediaTag = document.querySelector('video,audio')
     if (mediaTag) mediaTag.pause()
+  }
+  if (action === 'escapeBack') {
+    if (state.modal) {
+      dispatch('exitModal')
+    } else if (state.window.isFullScreen) {
+      dispatch('toggleFullScreen')
+    } else {
+      dispatch('back')
+    }
   }
   if (action === 'back') {
     state.location.back()
@@ -1144,18 +1150,6 @@ function onPaste (e) {
     if (torrentId.length === 0) return
     dispatch('addTorrent', torrentId)
   })
-}
-
-function onKeyDown (e) {
-  if (e.which === 27) { /* ESC means either exit fullscreen or go back */
-    if (state.modal) {
-      dispatch('exitModal')
-    } else if (state.window.isFullScreen) {
-      dispatch('toggleFullScreen')
-    } else {
-      dispatch('back')
-    }
-  }
 }
 
 function onFocus (e) {


### PR DESCRIPTION
The goal here is to remove shortcut handling from the renderer and
unify it all in menu.js and shortcuts.js (for alternate shortcuts).

- Added Playback menu with:
  - Play/Pause
  - Increase Volume (moved from View menu)
  - Decrease Volume (moved from View menu)

Also:

- Code cleanup to make menu.js more internally consistent.
  - Name the electron.dialog returned value `selectedPaths` which is more accurate.
  - Move the file menu into the `template` object, like the rest of the menus. Then reach in afterwards for OS-specific tweaks.

- Fix bug: Space key triggers power save block from torrent list