### PR TITLE
Remove require('screen')

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -196,8 +196,7 @@ function setBounds (bounds, maximize) {
     log('setBounds: setting bounds to ' + JSON.stringify(bounds))
     if (bounds.x === null && bounds.y === null) {
       // X and Y not specified? By default, center on current screen
-      var screen = require('screen')
-      var scr = screen.getDisplayMatching(windows.main.getBounds())
+      var scr = electron.screen.getDisplayMatching(windows.main.getBounds())
       bounds.x = Math.round(scr.bounds.x + scr.bounds.width / 2 - bounds.width / 2)
       bounds.y = Math.round(scr.bounds.y + scr.bounds.height / 2 - bounds.height / 2)
       log('setBounds: centered to ' + JSON.stringify(bounds))


### PR DESCRIPTION
This is deprecated usage and was just removed in Electron v1.