### PR TITLE
OS X: Make controls use full window in fullscreen

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -45,8 +45,8 @@ function init () {
     setBounds(bounds, maximize)
   })
 
-  ipcMain.on('setAspectRatio', function (e, aspectRatio, extraSize) {
-    setAspectRatio(aspectRatio, extraSize)
+  ipcMain.on('setAspectRatio', function (e, aspectRatio) {
+    setAspectRatio(aspectRatio)
   })
 
   ipcMain.on('setBadge', function (e, text) {
@@ -206,10 +206,10 @@ function setBounds (bounds, maximize) {
   }
 }
 
-function setAspectRatio (aspectRatio, extraSize) {
-  log('setAspectRatio %o %o', aspectRatio, extraSize)
+function setAspectRatio (aspectRatio) {
+  log('setAspectRatio %o', aspectRatio)
   if (windows.main) {
-    windows.main.setAspectRatio(aspectRatio, extraSize)
+    windows.main.setAspectRatio(aspectRatio)
   }
 }
 

--- a/main/menu.js
+++ b/main/menu.js
@@ -35,6 +35,10 @@ function toggleFullScreen (flag) {
   log('toggleFullScreen %s', flag)
   if (windows.main && windows.main.isVisible()) {
     flag = flag != null ? flag : !windows.main.isFullScreen()
+    if (flag) {
+      // Allows the window to use the full screen in fullscreen mode (OS X).
+      windows.main.setAspectRatio(0)
+    }
     windows.main.setFullScreen(flag)
   }
 }

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -441,6 +441,10 @@ function setupIpc () {
 
   ipcRenderer.on('fullscreenChanged', function (e, isFullScreen) {
     state.window.isFullScreen = isFullScreen
+    if (!isFullScreen) {
+      // Aspect ratio gets reset in fullscreen mode, so restore it (OS X)
+      ipcRenderer.send('setAspectRatio', state.playing.aspectRatio)
+    }
     update()
   })
 
@@ -1079,6 +1083,7 @@ function setDimensions (dimensions) {
 
   ipcRenderer.send('setAspectRatio', aspectRatio)
   ipcRenderer.send('setBounds', {x: null, y: null, width, height})
+  state.playing.aspectRatio = aspectRatio
 }
 
 function restoreBounds () {

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -77,7 +77,8 @@ function getDefaultPlayState () {
     subtitles: {
       tracks: [], /* subtitles file (Buffer) */
       enabled: false
-    }
+    },
+    aspectRatio: 0 /* aspect ratio of the video */
   }
 }
 


### PR DESCRIPTION
This bug was subtle. Basically, on OS X only, we use
window.setAspectRatio() to make the player window match the video size.

But this is maintained even in fullscreen mode, which makes the window
actually not use up the fullscreen, and there are black bars above and
below the video player controls, which looks really weird.

Unset the aspect ratio in fullscreen mode, then set it again upon
leaving fullscreen mode.