### PR TITLE
OS X: Volume slider nub should not move window

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -799,6 +799,7 @@ body.drag .app::after {
   border: none;
   padding: 0;
   vertical-align: sub;
+  -webkit-app-region: no-drag;
 }
 
 .player-controls .volume-slider::-webkit-slider-thumb {
@@ -809,6 +810,7 @@ body.drag .app::after {
   height: 10px;
   border: 1px solid #303233;
   border-radius: 50%;
+  -webkit-app-region: no-drag;
 }
 
 .player-controls .volume-slider:focus {

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -600,10 +600,6 @@ body.drag .app::after {
   padding: 8em 20px 20px 20px;
 }
 
-.torrent-details .open-folder {
-  float: right;
-}
-
 .torrent-details table {
   width: 100%;
   white-space: nowrap;
@@ -615,8 +611,7 @@ body.drag .app::after {
   height: 28px;
 }
 
-.torrent-details tr:hover,
-.torrent-details .open-folder:hover {
+.torrent-details tr:hover {
   background-color: rgba(200, 200, 200, 0.3);
 }
 


### PR DESCRIPTION
Before this PR, grabbing the volume slider nub would move the window.