### PR TITLE
Fix isProduction() detection

### DIFF
--- a/config.js
+++ b/config.js
@@ -69,7 +69,7 @@ function isProduction () {
     return false
   }
   if (process.platform === 'darwin') {
-    return !/\/Electron\.app\/Contents\/MacOS\/Electron$/.test(process.execPath)
+    return !/\/Electron\.app\//.test(process.execPath)
   }
   if (process.platform === 'win32') {
     return !/\\electron\.exe$/.test(process.execPath)


### PR DESCRIPTION
In the renderer process on OS X, config.IS_PRODUCTION was always true
because process.execPath is to "Electron Helper", so the detection
regex was being overly specific.