### PR TITLE
Only build 32-bit binaries for Windows

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -135,8 +135,8 @@ var win32 = {
   // Build for Windows.
   platform: 'win32',
 
-  // Build 64 bit binaries only.
-  arch: 'x64',
+  // Build 32 bit binaries only.
+  arch: 'ia32',
 
   // Object hash of application metadata to embed into the executable (Windows only)
   'version-string': {


### PR DESCRIPTION
Background on this change: https://github.com/feross/webtorrent-desktop/issues/437#issuecomment-219172469

It appears that the Atom team just ships a 32-bit binary to all Windows users.

https://github.com/atom/atom/issues/4881

Let's do the same, for now. This single 32-bit binary will work just fine on 32-bit and 64-bit Windows.