### PR TITLE
check if the subtitle label ends with a number

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -612,9 +612,10 @@ function addSubtitle (file) {
     state.playing.subtitles.tracks.forEach(function (trackItem) {
       trackItem.selected = false
       if (trackItem.label === track.label) {
-        track.label = Number.isNaN(track.label.slice(-1))
-          ? track.label + ' 2'
-          : track.label.slice(0, -1) + (parseInt(track.label.slice(-1)) + 1)
+        var labelParts = /([^\d]+)(\d+)$/.exec(track.label)
+        track.label = labelParts
+          ? labelParts[1] + (parseInt(labelParts[2]) + 1)
+          : track.label + ' 2'
       }
     })
     state.playing.subtitles.change = track.label


### PR DESCRIPTION
We need to check if the label ends with the string representation of a number

If you use Number.isNaN this happens

![image](https://cloud.githubusercontent.com/assets/6145761/15265479/13640414-195b-11e6-9f9a-44958189414b.png)

because Number.isNaN checks if the parameter is a numeric type