### PR TITLE
Better subtitles support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "electron-prebuilt": "1.0.2",
     "fs-extra": "^0.27.0",
     "hyperx": "^2.0.2",
+    "iso-639-1": "^1.2.1",
     "languagedetect": "^1.1.1",
     "main-loop": "^3.2.0",
     "musicmetadata": "^2.0.2",

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -9,7 +9,8 @@ var LocationHistory = require('./lib/location-history')
 module.exports = {
   getInitialState,
   getDefaultPlayState,
-  getDefaultSavedState
+  getDefaultSavedState,
+  getPlayingTorrentSummary
 }
 
 function getInitialState () {
@@ -57,7 +58,12 @@ function getInitialState () {
      *
      * Also accessible via `require('application-config')('WebTorrent').filePath`
      */
-    saved: {}
+    saved: {},
+
+    /*
+     * Getters, for convenience
+     */
+    getPlayingTorrentSummary
   }
 }
 
@@ -263,4 +269,9 @@ function getDefaultSavedState () {
       ? path.join(config.CONFIG_PATH, 'Downloads')
       : remote.app.getPath('downloads')
   }
+}
+
+function getPlayingTorrentSummary () {
+  var infoHash = this.playing.infoHash
+  return this.saved.torrents.find((x) => x.infoHash === infoHash)
 }

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -75,8 +75,9 @@ function getDefaultPlayState () {
     lastTimeUpdate: 0, /* Unix time in ms */
     mouseStationarySince: 0, /* Unix time in ms */
     subtitles: {
-      tracks: [], /* subtitles file (Buffer) */
-      enabled: false
+      tracks: [], /* subtitle tracks, each {label, language, ...} */
+      selectedIndex: -1, /* current subtitle track */
+      showMenu: false /* popover menu, above the video */
     },
     aspectRatio: 0 /* aspect ratio of the video */
   }

--- a/renderer/views/create-torrent-page.js
+++ b/renderer/views/create-torrent-page.js
@@ -30,6 +30,7 @@ function CreateTorrentPage (state) {
       pathPrefix = files[0]
     }
   }
+  console.log('WTF', pathPrefix, files)
 
   // Sanity check: show the number of files and total size
   var numFiles = files.length

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -161,7 +161,7 @@ function renderOverlay (state) {
 }
 
 function renderAudioMetadata (state) {
-  var torrentSummary = getPlayingTorrentSummary(state)
+  var torrentSummary = state.getPlayingTorrentSummary()
   var fileSummary = torrentSummary.files[state.playing.fileIndex]
   if (!fileSummary.audioInfo) return
   var info = fileSummary.audioInfo
@@ -200,7 +200,7 @@ function renderLoadingSpinner (state) {
     (new Date().getTime() - state.playing.lastTimeUpdate > 2000)
   if (!isProbablyStalled) return
 
-  var prog = getPlayingTorrentSummary(state).progress || {}
+  var prog = state.getPlayingTorrentSummary().progress || {}
   var fileProgress = 0
   if (prog.files) {
     var file = prog.files[state.playing.fileIndex]
@@ -493,7 +493,7 @@ var volumeChanging = false
 // Renders the loading bar. Shows which parts of the torrent are loaded, which
 // can be "spongey" / non-contiguous
 function renderLoadingBar (state) {
-  var torrentSummary = getPlayingTorrentSummary(state)
+  var torrentSummary = state.getPlayingTorrentSummary()
   if (!torrentSummary.progress) {
     return []
   }
@@ -530,7 +530,7 @@ function renderLoadingBar (state) {
 
 // Returns the CSS background-image string for a poster image + dark vignette
 function cssBackgroundImagePoster (state) {
-  var torrentSummary = getPlayingTorrentSummary(state)
+  var torrentSummary = state.getPlayingTorrentSummary()
   var posterPath = TorrentSummary.getPosterPath(torrentSummary)
   if (!posterPath) return ''
   return cssBackgroundImageDarkGradient() + `, url(${posterPath})`
@@ -539,9 +539,4 @@ function cssBackgroundImagePoster (state) {
 function cssBackgroundImageDarkGradient () {
   return 'radial-gradient(circle at center, ' +
     'rgba(0,0,0,0.4) 0%, rgba(0,0,0,1) 100%)'
-}
-
-function getPlayingTorrentSummary (state) {
-  var infoHash = state.playing.infoHash
-  return state.saved.torrents.find((x) => x.infoHash === infoHash)
 }

--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -157,9 +157,7 @@ function getTorrentFileInfo (file) {
   return {
     name: file.name,
     length: file.length,
-    path: file.path,
-    numPiecesPresent: 0,
-    numPieces: null
+    path: file.path
   }
 }
 


### PR DESCRIPTION
- [x] Simplify. Remove redundant `state.playing.subtitles.enabled`. Remove hacks like regex-parsing the 'label' of each subtitle, using the label as the identifier, etc
- [x] Detect subtitles next a video file automatically
- [x] Default to the user's language instead of just the first subtitle track