### PR TITLE
Remove `cursor:pointer`

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -113,16 +113,8 @@ table {
   opacity: 0.3;
 }
 
-.clickable {
-  cursor: pointer;
-}
-
 .float-right {
   float: right;
-}
-
-.expand-collapse {
-  cursor: pointer;
 }
 
 .expand-collapse.expanded::before {
@@ -370,7 +362,6 @@ button { /* Rectangular text buttons */
   border-radius: 3px;
   font-size: 14px;
   font-weight: bold;
-  cursor: pointer;
   color: #aaa;
   outline: none;
 }

--- a/renderer/views/torrent-list.js
+++ b/renderer/views/torrent-list.js
@@ -229,7 +229,7 @@ function TorrentList (state) {
       icon = 'description' /* file icon, opens in OS default app */
       handleClick = dispatcher('openFile', infoHash, index)
     }
-    var rowClass = 'clickable'
+    var rowClass = ''
     if (!isSelected) rowClass = 'disabled' // File deselected, not being torrented
     if (!isDone && !isPlayable) rowClass = 'disabled' // Can't open yet, can't stream
     return hx`


### PR DESCRIPTION
Apparently that's only for websites & we want to feel native