### PR TITLE
add audio visualizer

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -845,6 +845,9 @@ body.drag .app::after {
   text-shadow: #000 -1px 0 1px, #000 1px 0 1px, #000 0 -1px 1px, #000 0 1px 1px, rgba(50, 50, 50, 0.5) 2px 2px 0;
 }
 
+.visualizer {
+  width:100%;
+}
 
 /*
  * CHROMECAST / AIRPLAY CONTROLS

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -533,8 +533,8 @@ function renderLoadingBar (state) {
           width: (100 * part.count / fileProg.numPieces) + '%'
         }
 
-    return hx`<div class='loading-bar-part' style=${style}></div>`
-  })}
+        return hx`<div class='loading-bar-part' style=${style}></div>`
+      })}
     </div>
   `
 }

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -8,7 +8,10 @@ var prettyBytes = require('prettier-bytes')
 var Bitfield = require('bitfield')
 
 var TorrentSummary = require('../lib/torrent-summary')
+var visualizeAudio = require('./visualize-audio.js')
+
 var {dispatch, dispatcher} = require('../lib/dispatcher')
+var visualizer
 
 // Shows a streaming video player. Standard features + Chromecast + Airplay
 function Player (state) {
@@ -110,6 +113,10 @@ function renderMedia (state) {
 
   // As soon as the video loads enough to know the video dimensions, resize the window
   function onLoadedMetadata (e) {
+    if (state.playing.type === 'audio') {
+      visualizer = visualizeAudio(e)
+    }
+
     if (state.playing.type !== 'video') return
     var video = e.target
     var dimensions = {
@@ -164,6 +171,10 @@ function renderAudioMetadata (state) {
   var torrentSummary = state.getPlayingTorrentSummary()
   var fileSummary = torrentSummary.files[state.playing.fileIndex]
   if (!fileSummary.audioInfo) return
+
+  if (visualizer && state.playing.isPaused) visualizer.stop()
+  if (visualizer && !state.playing.isPaused) visualizer.start()
+
   var info = fileSummary.audioInfo
 
   // Get audio track info
@@ -191,13 +202,13 @@ function renderAudioMetadata (state) {
   var emptyLabel = hx`<label></label>`
   elems.unshift(hx`<div class='audio-title'>${elems.length ? emptyLabel : undefined}${title}</div>`)
 
-  return hx`<div class='audio-metadata'>${elems}</div>`
+  return hx`<div><canvas class="visualizer"></canvas><div class='audio-metadata'>${elems}</div></div>`
 }
 
 function renderLoadingSpinner (state) {
   if (state.playing.isPaused) return
   var isProbablyStalled = state.playing.isStalled ||
-    (new Date().getTime() - state.playing.lastTimeUpdate > 2000)
+  (new Date().getTime() - state.playing.lastTimeUpdate > 2000)
   if (!isProbablyStalled) return
 
   var prog = state.getPlayingTorrentSummary().progress || {}
@@ -522,8 +533,8 @@ function renderLoadingBar (state) {
           width: (100 * part.count / fileProg.numPieces) + '%'
         }
 
-        return hx`<div class='loading-bar-part' style=${style}></div>`
-      })}
+    return hx`<div class='loading-bar-part' style=${style}></div>`
+  })}
     </div>
   `
 }

--- a/renderer/views/visualize-audio.js
+++ b/renderer/views/visualize-audio.js
@@ -1,0 +1,57 @@
+module.exports = visualizeAudio
+
+function visualizeAudio (e) {
+  var audioCtx = new window.AudioContext()
+  var analyser = audioCtx.createAnalyser()
+  analyser.fftSize = 32
+  analyser.connect(audioCtx.destination)
+
+  var source = audioCtx.createMediaElementSource(e.target)
+  source.connect(analyser)
+
+  // visualizations for audio are rendered outside of the hyperx context
+
+  var canvas = document.querySelector('.visualizer')
+  if (canvas) {
+    var canvasCtx = canvas.getContext('2d')
+    var WIDTH = canvas.width
+    var HEIGHT = canvas.height
+    var bufferLength = analyser.frequencyBinCount
+    var dataArray = new Uint8Array(bufferLength)
+  }
+
+  function draw () {
+    analyser.getByteFrequencyData(dataArray)
+
+    canvasCtx.fillStyle = 'rgb(0, 0, 0)'
+    canvasCtx.fillRect(0, 0, WIDTH, HEIGHT)
+
+    var barPadding = 2
+    var barWidth = (WIDTH - (2 * bufferLength)) / bufferLength
+    var barHeight
+    var x = 0
+
+    for (var i = 0; i < bufferLength; i++) {
+      barHeight = dataArray[i]
+
+      canvasCtx.fillStyle = 'rgb(239,51,76)'
+      canvasCtx.fillRect(x, HEIGHT - barHeight / 2, barWidth, barHeight / 2)
+
+      x += barWidth + barPadding
+    }
+
+    if (isRunning) window.requestAnimationFrame(() => draw())
+  }
+
+  var isRunning = false
+  return {
+    start: function () {
+      if (isRunning) return
+      isRunning = true
+      draw()
+    },
+    stop: function () {
+      isRunning = false
+    }
+  }
+}


### PR DESCRIPTION
Hello!

I'm unsure if this will cut the mustard, but here is a simple audio visualization to show when playing audio files.

![audio-visualizer](https://cloud.githubusercontent.com/assets/360233/15382845/8293fa6e-1d53-11e6-9661-31a2399fd47f.gif)

- The visualization is done using a `<canvas>` element outside of the regular rendering context.
- Should the `visualizer` instance live in the state instead of where it is now?
- Is this too CPU intensive?

Please review and feel free to push updates to the branch! 👍 