### PR TITLE
Always handle when the user clicks a magnet link or torrent file, or uses File > Open Torrent

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -213,6 +213,7 @@ function dispatch (action, ...args) {
     onOpen(args[0] /* files */)
   }
   if (action === 'addTorrent') {
+    backToList()
     addTorrent(args[0] /* torrent */)
   }
   if (action === 'showOpenTorrentFile') {
@@ -427,10 +428,15 @@ function openSubtitles () {
   })
 }
 
+// Quits any modal popovers and returns to the torrent list screen
 function backToList () {
   // Exit any modals and screens with a back button
   state.modal = null
   while (state.location.hasBack()) state.location.back()
+
+  // If we were already on the torrent list, scroll to the top
+  var contentTag = document.querySelector('.content')
+  if (contentTag) contentTag.scrollTop = 0
 
   // Work around virtual-dom issue: it doesn't expose its redraw function,
   // and only redraws on requestAnimationFrame(). That means when the user
@@ -555,7 +561,6 @@ function onOpen (files) {
   if (!Array.isArray(files)) files = [ files ]
 
   // Return to the home screen
-  state.modal = null
   backToList()
 
   if (files.every(isTorrent)) {
@@ -814,7 +819,7 @@ function torrentInfoHash (torrentKey, infoHash) {
       torrentKey: torrentKey,
       status: 'new'
     }
-    state.saved.torrents.push(torrentSummary)
+    state.saved.torrents.unshift(torrentSummary)
     sound.play('ADD')
   }
 
@@ -1266,8 +1271,10 @@ function onPaste (e) {
   torrentIds.forEach(function (torrentId) {
     torrentId = torrentId.trim()
     if (torrentId.length === 0) return
-    dispatch('addTorrent', torrentId)
+    addTorrent(torrentId)
   })
+
+  update()
 }
 
 function onFocus (e) {

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -54,12 +54,13 @@ function App (state) {
 function getErrorPopover (state) {
   var now = new Date().getTime()
   var recentErrors = state.errors.filter((x) => now - x.time < 5000)
+  var hasErrors = recentErrors.length > 0
 
   var errorElems = recentErrors.map(function (error) {
     return hx`<div class='error'>${error.message}</div>`
   })
   return hx`
-  <div class='error-popover ${recentErrors.length > 0 ? 'visible' : 'hidden'}'>
+    <div class='error-popover ${hasErrors ? 'visible' : 'hidden'}'>
       <div class='title'>Error</div>
       ${errorElems}
     </div>


### PR DESCRIPTION
- [x] If they're currently watching a video, kick them back out to the torrent list and create a new torrent
- [x] Close any open modal windows
- [x] Scroll to the bottom of the torrent list, so that the new item is visible

Later, in a separate PR, we'll make it so that Webtorrent Desktop remembers your position in the videos you've watched. That way, it won't be as bad to automatically exit ppl out of their video.