### PR TITLE
Improve open behavior; Fix bugs in LocationHistory

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -1091,7 +1091,7 @@ function deleteTorrent (infoHash) {
   var index = state.saved.torrents.findIndex((x) => x.infoHash === infoHash)
   if (index > -1) state.saved.torrents.splice(index, 1)
   saveStateThrottled()
-  state.location.clearForward() // prevent user from going forward to a deleted torrent
+  state.location.clearForward('player') // prevent user from going forward to a deleted torrent
   sound.play('DELETE')
 }
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -213,7 +213,6 @@ function dispatch (action, ...args) {
     onOpen(args[0] /* files */)
   }
   if (action === 'addTorrent') {
-    backToList()
     addTorrent(args[0] /* torrent */)
   }
   if (action === 'showOpenTorrentFile') {
@@ -620,6 +619,7 @@ function getTorrentSummary (torrentKey) {
 // Adds a torrent to the list, starts downloading/seeding. TorrentID can be a
 // magnet URI, infohash, or torrent file: https://github.com/feross/webtorrent#clientaddtorrentid-opts-function-ontorrent-torrent-
 function addTorrent (torrentId) {
+  backToList()
   var torrentKey = state.nextTorrentKey++
   var path = state.saved.downloadPath
   if (torrentId.path) {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -306,7 +306,7 @@ function dispatch (action, ...args) {
     state.playing.isStalled = true
   }
   if (action === 'mediaError') {
-    if (state.location.current().url === 'player') {
+    if (state.location.url() === 'player') {
       state.playing.location = 'error'
       ipcRenderer.send('checkForVLC')
       ipcRenderer.once('checkForVLC', function (e, isInstalled) {
@@ -386,7 +386,7 @@ function pause () {
 }
 
 function playPause () {
-  if (state.location.current().url !== 'player') return
+  if (state.location.url() !== 'player') return
   if (state.playing.isPaused) {
     play()
   } else {
@@ -1236,7 +1236,7 @@ function showDoneNotification (torrent) {
 // * The video is paused
 // * The video is playing remotely on Chromecast or Airplay
 function showOrHidePlayerControls () {
-  var hideControls = state.location.current().url === 'player' &&
+  var hideControls = state.location.url() === 'player' &&
     state.playing.mouseStationarySince !== 0 &&
     new Date().getTime() - state.playing.mouseStationarySince > 2000 &&
     !state.playing.isPaused &&

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -807,6 +807,9 @@ function findFilesRecursive (fileOrFolder, cb) {
 function createTorrent (options) {
   var torrentKey = state.nextTorrentKey++
   ipcRenderer.send('wt-create-torrent', torrentKey, options)
+  state.location.backToFirst(function () {
+    state.location.clearForward('create-torrent')
+  })
 }
 
 function torrentInfoHash (torrentKey, infoHash) {

--- a/renderer/lib/location-history.js
+++ b/renderer/lib/location-history.js
@@ -6,6 +6,11 @@ function LocationHistory () {
   this._forward = []
   this._pending = false
 }
+
+LocationHistory.prototype.url = function () {
+  return this.current() && this.current().url
+}
+
 LocationHistory.prototype.current = function () {
   return this._history[this._history.length - 1]
 }

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -22,7 +22,7 @@ function App (state) {
   // * The mouse is over the controls or we're scrubbing (see CSS)
   // * The video is paused
   // * The video is playing remotely on Chromecast or Airplay
-  var hideControls = state.location.current().url === 'player' &&
+  var hideControls = state.location.url() === 'player' &&
     state.playing.mouseStationarySince !== 0 &&
     new Date().getTime() - state.playing.mouseStationarySince > 2000 &&
     !state.playing.isPaused &&
@@ -30,10 +30,10 @@ function App (state) {
 
   // Hide the header on Windows/Linux when in the player
   // On OSX, the header appears as part of the title bar
-  var hideHeader = process.platform !== 'darwin' && state.location.current().url === 'player'
+  var hideHeader = process.platform !== 'darwin' && state.location.url() === 'player'
 
   var cls = [
-    'view-' + state.location.current().url, /* e.g. view-home, view-player */
+    'view-' + state.location.url(), /* e.g. view-home, view-player */
     'is-' + process.platform /* e.g. is-darwin, is-win32, is-linux */
   ]
   if (state.window.isFullScreen) cls.push('is-fullscreen')
@@ -81,6 +81,6 @@ function getModal (state) {
 }
 
 function getView (state) {
-  var url = state.location.current().url
+  var url = state.location.url()
   return Views[url](state)
 }

--- a/renderer/views/create-torrent-page.js
+++ b/renderer/views/create-torrent-page.js
@@ -119,7 +119,6 @@ function CreateTorrentPage (state) {
       comment: comment
     }
     dispatch('createTorrent', options)
-    dispatch('backToList')
   }
 
   function handleCancel () {

--- a/renderer/views/create-torrent-page.js
+++ b/renderer/views/create-torrent-page.js
@@ -123,7 +123,7 @@ function CreateTorrentPage (state) {
   }
 
   function handleCancel () {
-    dispatch('backToList')
+    dispatch('back')
   }
 
   function handleToggleShowAdvanced () {

--- a/renderer/views/header.js
+++ b/renderer/views/header.js
@@ -37,7 +37,7 @@ function Header (state) {
   }
 
   function getAddButton () {
-    if (state.location.current().url !== 'player') {
+    if (state.location.url() !== 'player') {
       return hx`
         <i
           class='icon add'


### PR DESCRIPTION
Lots of intertwined changes here, might be easier to review commit-by-commit.

---

I don't think it matters whether the open comes from onOpen (opening
magnet, .torrent file, dragging file to dock, menu item) or from
dragging to the window.

These should use the same code path. The only relevant information is
the page of the app that we're on.

This change unifies the two methods, and supports dragging .torrent
files or creating a torrent when the player is active, if the dragged
files are not .srt or .vtt. We go back to the list, or to the create
torrent page in these situations, so it's not confusing for the user.

Always close open modals when handling an open.