### PR TITLE
VLC tweaks

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -107,11 +107,11 @@ function init () {
   })
 
   ipcMain.on('vlcPlay', function (e, url) {
-    var args = ['--play-and-exit', '--quiet', url]
+    var args = ['--play-and-exit', '--video-on-top', '--no-video-title-show', '--quiet', url]
     console.log('Running vlc ' + args.join(' '))
 
     vlc.spawn(args, function (err, proc) {
-      if (err) windows.main.send('dispatch', 'vlcNotFound')
+      if (err) return windows.main.send('dispatch', 'vlcNotFound')
       vlcProcess = proc
 
       // If it works, close the modal after a second


### PR DESCRIPTION
- Start video on top, so it's not obscured by other windows.

- Don't show "video title" which is just "http://localhost:xxxx"

- return after error