### PR TITLE
Add announcement feature 

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,8 +19,7 @@ module.exports = {
   APP_VERSION: APP_VERSION,
   APP_WINDOW_TITLE: APP_NAME + ' (BETA)',
 
-  AUTO_UPDATE_URL: 'https://webtorrent.io/desktop/update' +
-    '?version=' + APP_VERSION + '&platform=' + process.platform,
+  AUTO_UPDATE_URL: 'https://webtorrent.io/desktop/update',
 
   CRASH_REPORT_URL: 'https://webtorrent.io/desktop/crash-report',
 

--- a/config.js
+++ b/config.js
@@ -9,6 +9,8 @@ var APP_VERSION = require('./package.json').version
 var PORTABLE_PATH = path.join(path.dirname(process.execPath), 'Portable Settings')
 
 module.exports = {
+  ANNOUNCEMENT_URL: 'https://webtorrent.io/desktop/announcement',
+
   APP_COPYRIGHT: 'Copyright © 2014-2016 ' + APP_TEAM,
   APP_FILE_ICON: path.join(__dirname, 'static', 'WebTorrentFile'),
   APP_ICON: path.join(__dirname, 'static', 'WebTorrent'),

--- a/main/announcement.js
+++ b/main/announcement.js
@@ -17,11 +17,22 @@ function init () {
     if (err) return log('failed to retrieve remote message')
     if (res.statusCode !== 200) return log('no remote message')
 
+    try {
+      data = JSON.parse(data.toString())
+    } catch (err) {
+      data = {
+        title: 'WebTorrent Desktop Announcement',
+        message: 'WebTorrent Desktop Announcement',
+        detail: data.toString()
+      }
+    }
+
     electron.dialog.showMessageBox({
       type: 'info',
       buttons: ['OK'],
-      title: 'WebTorrent Desktop Announcement',
-      message: data.toString()
+      title: data.title,
+      message: data.message,
+      detail: data.detail
     })
   })
 }

--- a/main/announcement.js
+++ b/main/announcement.js
@@ -33,6 +33,6 @@ function init () {
       title: data.title,
       message: data.message,
       detail: data.detail
-    })
+    }, function () {})
   })
 }

--- a/main/announcement.js
+++ b/main/announcement.js
@@ -1,0 +1,27 @@
+module.exports = {
+  init
+}
+
+var electron = require('electron')
+var get = require('simple-get')
+
+var config = require('../config')
+var log = require('./log')
+
+var ANNOUNCEMENT_URL = config.ANNOUNCEMENT_URL +
+  '?version=' + config.APP_VERSION +
+  '&platform=' + process.platform
+
+function init () {
+  get.concat(ANNOUNCEMENT_URL, function (err, res, data) {
+    if (err) return log('failed to retrieve remote message')
+    if (res.statusCode !== 200) return log('no remote message')
+
+    electron.dialog.showMessageBox({
+      type: 'info',
+      buttons: ['OK'],
+      title: 'WebTorrent Desktop Announcement',
+      message: data.toString()
+    })
+  })
+}

--- a/main/index.js
+++ b/main/index.js
@@ -5,6 +5,7 @@ var electron = require('electron')
 var app = electron.app
 var ipcMain = electron.ipcMain
 
+var announcement = require('./announcement')
 var config = require('../config')
 var crashReporter = require('../crash-reporter')
 var handlers = require('./handlers')
@@ -91,6 +92,7 @@ function init () {
 }
 
 function delayedInit () {
+  announcement.init()
   tray.init()
   handlers.install()
   updater.init()

--- a/main/updater.js
+++ b/main/updater.js
@@ -9,6 +9,10 @@ var config = require('../config')
 var log = require('./log')
 var windows = require('./windows')
 
+var AUTO_UPDATE_URL = config.AUTO_UPDATE_URL +
+  '?version=' + config.APP_VERSION +
+  '&platform=' + process.platform
+
 function init () {
   if (process.platform === 'linux') {
     initLinux()
@@ -20,7 +24,7 @@ function init () {
 // The Electron auto-updater does not support Linux yet, so manually check for updates and
 // `show the user a modal notification.
 function initLinux () {
-  get.concat(config.AUTO_UPDATE_URL, onResponse)
+  get.concat(AUTO_UPDATE_URL, onResponse)
 
   function onResponse (err, res, data) {
     if (err) return log(`Update error: ${err.message}`)
@@ -67,6 +71,6 @@ function initDarwinWin32 () {
     (e, notes, name, date, url) => log(`Update downloaded: ${name}: ${url}`)
   )
 
-  electron.autoUpdater.setFeedURL(config.AUTO_UPDATE_URL)
+  electron.autoUpdater.setFeedURL(AUTO_UPDATE_URL)
   electron.autoUpdater.checkForUpdates()
 }


### PR DESCRIPTION
If there's a message returned by the given remote URL, then it will
show up for the user.

Useful in situations where the auto-updater is not working, or if
there's a security issue.