### PR TITLE
electron-prebuilt@1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dlnacasts": "^0.1.0",
     "drag-drop": "^2.11.0",
     "electron-localshortcut": "^0.6.0",
-    "electron-prebuilt": "1.0.2",
+    "electron-prebuilt": "1.1.1",
     "fs-extra": "^0.27.0",
     "hyperx": "^2.0.2",
     "iso-639-1": "^1.2.1",


### PR DESCRIPTION
No new features that affect us.

This release includes Chrome 50, which should improve the webrtc CPU usage situation on Linux. For the OS X improvement, we're still waiting for Chrome 51.