### PR TITLE
Handle unsupported video codec (e.g. H.265)

### DIFF
--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -129,6 +129,9 @@ function renderMedia (state) {
     if (video.webkitVideoDecodedByteCount > 0 &&
       video.webkitAudioDecodedByteCount === 0) {
       dispatch('mediaError', 'Audio codec unsupported')
+    } else if (state.playing.type === 'video' &&
+      video.webkitVideoDecodedByteCount === 0) {
+      dispatch('mediaError', 'Video codec unsupported')
     } else {
       video.play()
     }


### PR DESCRIPTION
Notifies when a video codec is not supported (such as H.265 in #561), and allows it to be played in vlc similar to how unsupported audio in videos are already handled.