### PR TITLE
More consistent controls

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -134,10 +134,10 @@ function onPlayerOpen () {
   getMenuItem('Increase Volume').enabled = true
   getMenuItem('Decrease Volume').enabled = true
   getMenuItem('Add Subtitles File...').enabled = true
-  getMenuItem('Skip forward 10 seconds').enabled = true
-  getMenuItem('Skip back 10 seconds').enabled = true
-  getMenuItem('Increase video speed').enabled = true
-  getMenuItem('Decrease video speed').enabled = true
+  getMenuItem('Step Forward').enabled = true
+  getMenuItem('Step Backward').enabled = true
+  getMenuItem('Increase Speed').enabled = true
+  getMenuItem('Decrease Speed').enabled = true
 }
 
 function onPlayerClose () {
@@ -146,10 +146,10 @@ function onPlayerClose () {
   getMenuItem('Increase Volume').enabled = false
   getMenuItem('Decrease Volume').enabled = false
   getMenuItem('Add Subtitles File...').enabled = false
-  getMenuItem('Skip forward 10 seconds').enabled = false
-  getMenuItem('Skip back 10 seconds').enabled = false
-  getMenuItem('Increase video speed').enabled = false
-  getMenuItem('Decrease video speed').enabled = false
+  getMenuItem('Step Forward').enabled = false
+  getMenuItem('Step Backward').enabled = false
+  getMenuItem('Increase Speed').enabled = false
+  getMenuItem('Decrease Speed').enabled = false
 }
 
 function onToggleFullScreen (isFullScreen) {
@@ -340,21 +340,13 @@ function getAppMenuTemplate () {
           type: 'separator'
         },
         {
-          label: 'Add Subtitles File...',
-          click: openSubtitles,
-          enabled: false
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Skip forward 10 seconds',
+          label: 'Step Forward',
           accelerator: 'CmdOrCtrl+Alt+Right',
           click: skipForward,
           enabled: false
         },
         {
-          label: 'Skip back 10 seconds',
+          label: 'Step Backward',
           accelerator: 'CmdOrCtrl+Alt+Left',
           click: skipBack,
           enabled: false
@@ -363,15 +355,23 @@ function getAppMenuTemplate () {
           type: 'separator'
         },
         {
-          label: 'Increase video speed',
-          accelerator: 'CmdOrCtrl+plus',
+          label: 'Increase Speed',
+          accelerator: 'CmdOrCtrl+=',
           click: increasePlaybackRate,
           enabled: false
         },
         {
-          label: 'Decrease video speed',
+          label: 'Decrease Speed',
           accelerator: 'CmdOrCtrl+-',
           click: decreasePlaybackRate,
+          enabled: false
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Add Subtitles File...',
+          click: openSubtitles,
           enabled: false
         }
       ]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "virtual-dom": "^2.1.1",
     "vlc-command": "^1.0.1",
     "webtorrent": "0.x",
-    "winreg": "^1.2.0"
+    "winreg": "^1.2.0",
+    "zero-fill": "^2.2.3"
   },
   "devDependencies": {
     "cross-zip": "^2.0.1",

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -739,7 +739,8 @@ body.drag .app::after {
   vertical-align: sub;
 }
 
-.player .controls .time {
+.player .controls .time,
+.player .controls .rate {
   font-weight: 100;
   font-size: 13px;
   margin: 9px 8px 8px 8px;
@@ -817,13 +818,6 @@ body.drag .app::after {
 .player .controls .closed-captions.active,
 .player .controls .device.active {
   color: #9af;
-}
-
-.player-controls .rate {
-  display: inline;
-  height: 30px;
-  padding: 5px;
-  margin-left: 20px;
 }
 
 .player .controls .volume-slider::-webkit-slider-thumb {

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -94,9 +94,18 @@ table {
   word-wrap: normal;
   white-space: nowrap;
   direction: ltr;
+  opacity: 0.85;
 
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+}
+
+.icon.disabled {
+  opacity: 0.3;
+}
+
+.icon:not(.disabled):hover {
+  opacity: 1;
 }
 
 /*
@@ -109,8 +118,8 @@ table {
   white-space: nowrap;
 }
 
-.disabled {
-  opacity: 0.3;
+.float-left {
+  float: left;
 }
 
 .float-right {
@@ -144,8 +153,8 @@ table {
 .header {
   background: rgb(40, 40, 40);
   border-bottom: 1px solid rgb(20, 20, 20);
-  height: 37px; /* vertically center OS menu buttons (OS X) */
-  padding-top: 6px;
+  height: 38px; /* vertically center OS menu buttons (OS X) */
+  padding-top: 7px;
   overflow: hidden;
   flex: 0 1 auto;
   opacity: 1;
@@ -164,7 +173,13 @@ table {
 }
 
 .app.view-player .header {
-  opacity: 0.8;
+  background: rgba(40, 40, 40, 0.8);
+  border-bottom: none;
+}
+
+.app.view-player.is-win32 .header,
+.app.view-player.is-linux .header {
+  background: none;
 }
 
 .app.hide-video-controls.view-player .header {
@@ -172,12 +187,8 @@ table {
   cursor: none;
 }
 
-.app.hide-header .header {
-  display: none;
-}
-
 .header .title {
-  opacity: 0.6;
+  opacity: 0.7;
   position: absolute;
   margin-top: 1px;
   padding: 0 150px 0 150px;
@@ -188,35 +199,22 @@ table {
 
 .header .nav {
   font-weight: bold;
-  margin-right: 9px;
 }
 
 .header .nav.left {
-  float: left;
+  margin-left: 10px;
+}
+
+.header .nav.right {
+  margin-right: 10px;
 }
 
 .app.is-darwin:not(.is-fullscreen) .header .nav.left {
   margin-left: 78px;
 }
 
-.header .nav.right {
-  float: right;
-}
-
-.header .nav * {
-  opacity: 0.6;
-}
-
-.header .nav .disabled {
-  opacity: 0.1;
-}
-
-.header .nav *:not(.disabled):hover {
-  opacity: 1;
-}
-
-.header .nav .back,
-.header .nav .forward {
+.header .back,
+.header .forward {
   font-size: 30px;
   margin-top: -3px;
 }
@@ -695,7 +693,7 @@ body.drag .app::after {
  * PLAYER CONTROLS
  */
 
-.player-controls {
+.player .controls {
   position: fixed;
   background: rgba(40, 40, 40, 0.8);
   width: 100%;
@@ -704,7 +702,62 @@ body.drag .app::after {
   transition: opacity 0.15s ease-out;
 }
 
-.app.hide-video-controls .player-controls {
+.player .controls .icon {
+  display: block;
+  margin: 8px;
+  font-size: 22px;
+  opacity: 0.85;
+
+  /*
+   * Fix for overflowing captions icon
+   * https://github.com/feross/webtorrent-desktop/issues/467
+   */
+  max-width: 23px;
+  overflow: hidden;
+}
+
+.player .controls .icon:hover {
+  opacity: 1;
+}
+
+.player .controls .play-pause {
+  font-size: 28px;
+  margin-top: 5px;
+  margin-right: 10px;
+  margin-left: 15px;
+}
+
+.player .controls .volume-slider {
+  -webkit-appearance: none;
+  -webkit-app-region: no-drag;
+  width: 60px;
+  height: 3px;
+  margin: 18px 8px 8px 0;
+  border: none;
+  padding: 0;
+  opacity: 0.85;
+  vertical-align: sub;
+}
+
+.player .controls .time {
+  font-weight: 100;
+  font-size: 13px;
+  margin: 9px 8px 8px 8px;
+  opacity: 0.8;
+}
+
+.player .controls .icon.closed-captions {
+  font-size: 26px;
+  margin-top: 6px;
+}
+
+.player .controls .icon.fullscreen {
+  font-size: 26px;
+  margin-right: 15px;
+  margin-top: 6px;
+}
+
+.app.hide-video-controls .player .controls {
   opacity: 0;
 }
 
@@ -712,13 +765,16 @@ body.drag .app::after {
   cursor: none;
 }
 
-.app.hide-video-controls .player .player-controls:hover {
+/* TODO: find better way to handle this (that also
+ * keeps the header visible too).
+ */
+.app.hide-video-controls .player .controls:hover {
   opacity: 1;
   cursor: default;
 }
 
 /* invisible click target for scrubbing */
-.player-controls .scrub-bar {
+.player .controls .scrub-bar {
   position: absolute;
   width: 100%;
   height: 23px; /* 3px .loading-bar plus 10px above and below */
@@ -727,7 +783,7 @@ body.drag .app::after {
   -webkit-app-region: no-drag;
 }
 
-.player-controls .loading-bar {
+.player .controls .loading-bar {
   position: relative;
   width: 100%;
   top: -3px;
@@ -737,14 +793,14 @@ body.drag .app::after {
   position: absolute;
 }
 
-.player-controls .loading-bar-part {
+.player .controls .loading-bar-part {
   position: absolute;
   background-color: #dd0000;
   top: 0;
   height: 100%;
 }
 
-.player-controls .playback-cursor {
+.player .controls .playback-cursor {
   position: absolute;
   top: -3px;
   background-color: #FFF;
@@ -758,102 +814,29 @@ body.drag .app::after {
   transition-timing-function: ease-out;
 }
 
-.player-controls .play-pause {
-  display: block;
-  width: 30px;
-  height: 30px;
-  padding: 5px;
-  margin: 0 auto;
+.player .controls .closed-captions.active,
+.player .controls .device.active {
+  color: #9af;
 }
+
 .player-controls .rate {
   display: inline;
   height: 30px;
   padding: 5px;
   margin-left: 20px;
-  float: left;
 }
 
-.player-controls .device,
-.player-controls .fullscreen,
-.player-controls .closed-captions,
-.player-controls .volume-icon,
-.player-controls .back {
-  display: block;
-  height: 20px;
-  margin: 5px;
-
-  /*
-   * Fix for overflowing captions icon
-   * https://github.com/feross/webtorrent-desktop/issues/467
-   */
-  max-width: 22px;
-  overflow: hidden;
-}
-
-.player-controls .volume,
-.player-controls .back {
-  float: left;
-}
-
-.player-controls .device,
-.player-controls .closed-captions,
-.player-controls .fullscreen {
-  float: right;
-}
-
-.player-controls .fullscreen {
-  margin-right: 15px;
-}
-
-.player-controls .volume-icon,
-.player-controls .device {
-  font-size: 18px; /* make the cast icons less huge */
-  margin-top: 8px !important;
-}
-
-.player-controls .closed-captions.active,
-.player-controls .device.active {
-  color: #9af;
-}
-
-.player-controls .volume {
-  display: block;
-  width: 90px;
-}
-
-.player-controls .volume-icon {
-  float: left;
-  margin-right: 0px;
-}
-
-.player-controls .volume-slider {
+.player .controls .volume-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 50px;
-  height: 3px;
-  border: none;
-  padding: 0;
-  vertical-align: sub;
   -webkit-app-region: no-drag;
-}
-
-.player-controls .volume-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
   background-color: #fff;
-  opacity: 1.0;
-  width: 10px;
-  height: 10px;
-  border: 1px solid #303233;
+  width: 13px;
+  height: 13px;
   border-radius: 50%;
-  -webkit-app-region: no-drag;
 }
 
-.player-controls .volume-slider:focus {
+.player .controls .volume-slider:focus {
   outline: none;
-}
-
-.player-controls .time {
-  float: left;
-  line-height: 33px;
 }
 
 .player .playback-bar:hover .loading-bar {
@@ -997,10 +980,6 @@ video::-webkit-media-text-track-container {
   width: 100%;
   overflow: hidden;
   z-index: 1;
-}
-
-.app.hide-header .error-popover {
-  top: 0px;
 }
 
 .error-popover.hidden {

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -29,10 +29,6 @@ function App (state) {
     state.playing.location === 'local' &&
     state.playing.playbackRate === 1
 
-  // Hide the header on Windows/Linux when in the player
-  // On OSX, the header appears as part of the title bar
-  var hideHeader = process.platform !== 'darwin' && state.location.url() === 'player'
-
   var cls = [
     'view-' + state.location.url(), /* e.g. view-home, view-player */
     'is-' + process.platform /* e.g. is-darwin, is-win32, is-linux */
@@ -40,7 +36,6 @@ function App (state) {
   if (state.window.isFullScreen) cls.push('is-fullscreen')
   if (state.window.isFocused) cls.push('is-focused')
   if (hideControls) cls.push('hide-video-controls')
-  if (hideHeader) cls.push('hide-header')
 
   return hx`
     <div class='app ${cls.join(' ')}'>

--- a/renderer/views/header.js
+++ b/renderer/views/header.js
@@ -10,7 +10,7 @@ function Header (state) {
   return hx`
     <div class='header'>
       ${getTitle()}
-      <div class='nav left'>
+      <div class='nav left float-left'>
         <i.icon.back
           class=${state.location.hasBack() ? '' : 'disabled'}
           title='Back'
@@ -24,7 +24,7 @@ function Header (state) {
           chevron_right
         </i>
       </div>
-      <div class='nav right'>
+      <div class='nav right float-right'>
         ${getAddButton()}
       </div>
     </div>

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -452,7 +452,7 @@ function renderPlayerControls (state) {
   if (state.playing.playbackRate !== 1) {
     elements.push(hx`
       <span class='rate float-left'>
-        speed: ${state.playing.playbackRate}X
+        ${state.playing.playbackRate}x
       </span>
     `)
   }


### PR DESCRIPTION
Tried to match the YouTube player UI more closely. There's still work to do, but this is a huge improvement for consistency:

![screen shot 2016-05-22 at 21 59 22](https://cloud.githubusercontent.com/assets/121766/15460680/80662e34-2068-11e6-8742-af38d6fb8652.png)

Compare to:

![screen shot 2016-05-22 at 22 15 54](https://cloud.githubusercontent.com/assets/121766/15460882/cb8a6838-206a-11e6-8988-4de0d05150d1.png)

- Increased size of all controls
- All buttons consistently get lighter on hover, without redundant css
- Play button moves to left, just like YouTube
- Time tweaks: thinner font, less verbose (0:xx instead of 00:xx, and omit hours when they're 0)
- Bigger volume slider nub
- Show back/forward buttons in top left on Windows/Linux, when in player
  - So it's consistent with OS X version, and the back button doesn't move around
  - Also, there are technically situations in which the forward button is needed from the player
    - Like if you start creating a torrent from the player, then go back, then want to go forward again
  - Make the background of the header bar transparent since it's mostly empty and looks terrible otherwise

This is what it looks like on Windows:

<img width="981" alt="screen shot 2016-05-22 at 22 12 47" src="https://cloud.githubusercontent.com/assets/121766/15460863/83354102-206a-11e6-9e47-502a959a0beb.png">
