### PR TITLE
Bugfix: pick default file to play on default torrents

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -273,14 +273,7 @@ function dispatch (action, ...args) {
     playPause()
   }
   if (action === 'play') {
-    state.location.go({
-      url: 'player',
-      onbeforeload: function (cb) {
-        play()
-        openPlayer(args[0] /* infoHash */, args[1] /* index */, cb)
-      },
-      onbeforeunload: closePlayer
-    })
+    playFile(args[0] /* infoHash */, args[1] /* index */)
   }
   if (action === 'playbackJump') {
     jumpToTime(args[0] /* seconds */)
@@ -992,7 +985,20 @@ function pickFileToPlay (files) {
   return undefined
 }
 
-// Opens the video player
+function playFile (infoHash, index) {
+  state.location.go({
+    url: 'player',
+    onbeforeload: function (cb) {
+      play()
+      openPlayer(infoHash, index, cb)
+    },
+    onbeforeunload: closePlayer
+  }, function (err) {
+    if (err) onError(err)
+  })
+}
+
+// Opens the video player to a specific torrent
 function openPlayer (infoHash, index, cb) {
   var torrentSummary = getTorrentSummary(infoHash)
 

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -998,6 +998,7 @@ function openPlayer (infoHash, index, cb) {
 
   // automatically choose which file in the torrent to play, if necessary
   if (index === undefined) index = torrentSummary.defaultPlayFileIndex
+  if (index === undefined) index = pickFileToPlay(torrentSummary.files)
   if (index === undefined) return cb(new errors.UnplayableError())
 
   // update UI to show pending playback


### PR DESCRIPTION
Right now, clicking Play on one of the default torrents doesn't work, because they don't have `defaultFileToPlay`

Torrents can exist in one of a few states. Maybe we should make this more explicit in a future PR to help prevent future bugs. Possible states:
1. New default torrent. These have a list of files and infohash, but no `path`, no full torrent metadata, no `progress`, and no `defaultFileToPlay`
2. Newly added magnet link. These have an infohash and basically nothing else. They show up as "Loading torrent..."
3. Newly added files to seed. These have a list of files and basically nothing else, not even an infohash.
4. Normal torrent. These have everything as well as a `progress` object to track downloading / seeding.
5. Stopped torrent. These have everything except a `progress` object.

1, 2, and 3, turn into 4 as soon as they get the `metadata` event. The blue button toggles between 4 and 5.