### PR TITLE
Adding duplicate torrent when stopped

### DIFF
--- a/renderer/main.js
+++ b/renderer/main.js
@@ -878,12 +878,21 @@ function torrentInfoHash (torrentKey, infoHash) {
     torrentSummary ? 'existing' : 'new', torrentKey)
 
   if (!torrentSummary) {
-    torrentSummary = {
-      torrentKey: torrentKey,
-      status: 'new'
+    // Check if another torrent has the same infoHash
+    var duplicate = state.saved.torrents.find((x) => x.infoHash === infoHash)
+
+    if (duplicate) {
+      duplicate.torrentKey = torrentKey
+      duplicate.status = 'new'
+      sound.play('ENABLE')
+    } else {
+      torrentSummary = {
+        torrentKey: torrentKey,
+        status: 'new'
+      }
+      state.saved.torrents.unshift(torrentSummary)
+      sound.play('ADD')
     }
-    state.saved.torrents.unshift(torrentSummary)
-    sound.play('ADD')
   }
 
   torrentSummary.infoHash = infoHash


### PR DESCRIPTION
I took a look at the issue #581 i created about adding a stopped torrent that is already in the list.
I was able to fix the issue by replacing the torrentKey of the first torrent with the key of the duplicate, and mimic a toggleTorrent.

This is not an elegant solution, but maybe it could do for now?

Also, I was wondering why a torrent have a torrentKey instead of being identified by the infoHash?
