### PR TITLE
Re-enable WebRTC (OS X, Windows)

### DIFF
--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -31,10 +31,10 @@ global.WEBTORRENT_ANNOUNCE = defaultAnnounceList
 var client = new WebTorrent()
 
 // WebTorrent-to-HTTP streaming sever
-var server = window.server = null
+var server = null
 
 // Used for diffing, so we only send progress updates when necessary
-var prevProgress = window.prevProgress = null
+var prevProgress = null
 
 init()
 

--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -28,16 +28,7 @@ global.WEBTORRENT_ANNOUNCE = defaultAnnounceList
 
 // Connect to the WebTorrent and BitTorrent networks. WebTorrent Desktop is a hybrid
 // client, as explained here: https://webtorrent.io/faq
-var client = window.client = new WebTorrent({
-  tracker: {
-    // HACK: OS X: Disable WebRTC peers to fix 100% CPU issue caused by Chrome bug.
-    // Fixed in Chrome 51, so we can remove this hack once Electron updates Chrome.
-    // Issue: https://github.com/feross/webtorrent-desktop/issues/353
-    // HACK #2: Windows: Disable WebRTC to fix Chrome 50 / Electron 1.1.[1-3] crash.
-    // Issue: https://github.com/electron/electron/issues/5629
-    wrtc: process.platform === 'linux'
-  }
-})
+var client = new WebTorrent()
 
 // WebTorrent-to-HTTP streaming sever
 var server = window.server = null


### PR DESCRIPTION
Tested on OS X, Windows. No immediate crash.

Let's merge to master so we can test all day today to see if the 100% CPU issue is gone from OS X for good. Closes #353.