### PR TITLE
Upgrade to Electron 1.2.0. Re-enable WebRTC on OSX and Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deep-equal": "^1.0.1",
     "dlnacasts": "^0.1.0",
     "drag-drop": "^2.11.0",
-    "electron-prebuilt": "1.1.1",
+    "electron-prebuilt": "1.2.0",
     "fs-extra": "^0.27.0",
     "hyperx": "^2.0.2",
     "iso-639-1": "^1.2.1",

--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -28,16 +28,7 @@ global.WEBTORRENT_ANNOUNCE = defaultAnnounceList
 
 // Connect to the WebTorrent and BitTorrent networks. WebTorrent Desktop is a hybrid
 // client, as explained here: https://webtorrent.io/faq
-var client = window.client = new WebTorrent({
-  tracker: {
-    // HACK: OS X: Disable WebRTC peers to fix 100% CPU issue caused by Chrome bug.
-    // Fixed in Chrome 51, so we can remove this hack once Electron updates Chrome.
-    // Issue: https://github.com/feross/webtorrent-desktop/issues/353
-    // HACK #2: Windows: Disable WebRTC to fix Chrome 50 / Electron 1.1.[1-3] crash.
-    // Issue: https://github.com/electron/electron/issues/5629
-    wrtc: process.platform === 'linux'
-  }
-})
+var client = window.client = new WebTorrent()
 
 // WebTorrent-to-HTTP streaming sever
 var server = window.server = null


### PR DESCRIPTION
Electron 1.2.0 is based on Chrome 51, and fixes two bad bugs: the openDataChannel crash on Windows and the WebRTC 100% CPU bug on OSX

@feross 