### PR TITLE
Fix issue with tray on Windows.

### DIFF
--- a/main/tray.js
+++ b/main/tray.js
@@ -80,7 +80,7 @@ function createTray () {
 }
 
 function updateTrayMenu () {
-  var contextMenu = electron.Menu.buildFromTemplate(getMenuTemplate)
+  var contextMenu = electron.Menu.buildFromTemplate(getMenuTemplate())
   tray.setContextMenu(contextMenu)
 }
 


### PR DESCRIPTION
Note: There is still an issue with the tray, when the WebTorrent app is hidden, the tray item "Hide to tray" does not change to "Show WebTorrent", but I can't seem to figure out how to fix it.