### PR TITLE
Make add button accept non .torrent files (seeding)

### DIFF
--- a/main/dialog.js
+++ b/main/dialog.js
@@ -2,7 +2,8 @@ module.exports = {
   openSeedFile,
   openSeedDirectory,
   openTorrentFile,
-  openTorrentAddress
+  openTorrentAddress,
+  openAddFiles
 }
 
 var electron = require('electron')
@@ -81,6 +82,24 @@ function openTorrentFile () {
 function openTorrentAddress () {
   log('openTorrentAddress')
   windows.main.dispatch('openTorrentAddress')
+}
+
+/*
+ * Show open dialog for all file types (.torrent, files to seed)
+ */
+function openAddFiles () {
+  if (!windows.main.win) return
+  log('openAddFiles')
+  var opts = {
+    title: 'Select a .torrent file to open or start seeding files.',
+    properties: [ 'openFile', 'multiSelections' ]
+  }
+  setTitle(opts.title)
+  electron.dialog.showOpenDialog(windows.main.win, opts, function (selectedPaths) {
+    resetTitle()
+    if (!Array.isArray(selectedPaths)) return
+    windows.main.dispatch('onOpen', selectedPaths)
+  })
 }
 
 /**

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -46,6 +46,7 @@ function init () {
    */
 
   ipc.on('openTorrentFile', () => dialog.openTorrentFile())
+  ipc.on('openAddFiles', () => dialog.openAddFiles())
 
   /**
    * Dock

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -227,6 +227,9 @@ function dispatch (action, ...args) {
   if (action === 'openTorrentFile') {
     ipcRenderer.send('openTorrentFile') /* open torrent file */
   }
+  if (action === 'openAddFiles') {
+    ipcRenderer.send('openAddFiles') /* add files with dialog */
+  }
   if (action === 'showCreateTorrent') {
     showCreateTorrent(args[0] /* paths */)
   }

--- a/renderer/views/header.js
+++ b/renderer/views/header.js
@@ -39,7 +39,7 @@ function Header (state) {
         <i
           class='icon add'
           title='Add torrent'
-          onclick=${dispatcher('openTorrentFile')}>
+          onclick=${dispatcher('openAddFiles')}>
           add
         </i>
       `


### PR DESCRIPTION
Making the add button consistent with drag and drop as described in #246, is this correct?

Note that the `openTorrentFile` dispatch is no longer used, should it be removed?