### PR TITLE
Fix 'fullscreen' and 'always on top' menu items

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -149,12 +149,12 @@ function getMenuTemplate () {
           accelerator: process.platform === 'darwin'
             ? 'Ctrl+Command+F'
             : 'F11',
-          click: () => windows.toggleFullScreen()
+          click: () => windows.main.toggleFullScreen()
         },
         {
           label: 'Float on Top',
           type: 'checkbox',
-          click: () => windows.toggleAlwaysOnTop()
+          click: () => windows.main.toggleAlwaysOnTop()
         },
         {
           type: 'separator'

--- a/main/windows/main.js
+++ b/main/windows/main.js
@@ -174,10 +174,10 @@ function show () {
 function toggleAlwaysOnTop (flag) {
   if (!main.win) return
   if (flag == null) {
-    flag = !main.isAlwaysOnTop()
+    flag = !main.win.isAlwaysOnTop()
   }
   log(`toggleAlwaysOnTop ${flag}`)
-  main.setAlwaysOnTop(flag)
+  main.win.setAlwaysOnTop(flag)
   menu.onToggleAlwaysOnTop(flag)
 }
 


### PR DESCRIPTION
Fixes #608.

Should the menu item `Float on Top` be renamed to `Always on Top` as the function?