### PR TITLE
Use correct icon name

### DIFF
--- a/renderer/main.css
+++ b/renderer/main.css
@@ -715,10 +715,7 @@ body.drag .app::after {
   font-size: 22px;
   opacity: 0.85;
 
-  /*
-   * Fix for overflowing captions icon
-   * https://github.com/feross/webtorrent-desktop/issues/467
-   */
+  /* Make all icons have uniform spacing */
   max-width: 23px;
   overflow: hidden;
 }
@@ -754,7 +751,7 @@ body.drag .app::after {
   opacity: 0.8;
 }
 
-.player .controls .icon.closed-captions {
+.player .controls .icon.closed-caption {
   font-size: 26px;
   margin-top: 6px;
 }
@@ -822,7 +819,7 @@ body.drag .app::after {
   transition-timing-function: ease-out;
 }
 
-.player .controls .closed-captions.active,
+.player .controls .closed-caption.active,
 .player .controls .device.active {
   color: #9af;
 }

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -363,10 +363,10 @@ function renderPlayerControls (state) {
   if (state.playing.type === 'video') {
     // show closed captions icon
     elements.push(hx`
-      <i.icon.closed-captions.float-right
+      <i.icon.closed-caption.float-right
         class=${captionsClass}
         onclick=${handleSubtitles}>
-        closed_captions
+        closed_caption
       </i>
     `)
   }


### PR DESCRIPTION
https://github.com/feross/webtorrent-desktop/issues/467

The icon name is "closed_caption", not "closed_captions"
http://jsbin.com/fenejob/1/edit?html,output

The extra space we're seeing is the icon font rendering the 's', which
renders as nothing.