### PR TITLE
Fix IPC race condition in startup 

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -327,11 +327,11 @@ function buildDarwin (cb) {
       }
 
       var dmg = appDmg(dmgOpts)
-      dmg.on('error', cb)
+      dmg.once('error', cb)
       dmg.on('progress', function (info) {
         if (info.type === 'step-begin') console.log(info.title + '...')
       })
-      dmg.on('finish', function (info) {
+      dmg.once('finish', function (info) {
         console.log('OS X: Created dmg.')
         cb(null)
       })

--- a/main/index.js
+++ b/main/index.js
@@ -103,13 +103,12 @@ function onOpen (e, torrentId) {
   e.preventDefault()
 
   if (app.ipcReady) {
-    windows.main.dispatch('onOpen', torrentId)
     // Magnet links opened from Chrome won't focus the app without a setTimeout.
     // The confirmation dialog Chrome shows causes Chrome to steal back the focus.
     // Electron issue: https://github.com/atom/electron/issues/4338
-    setTimeout(function () {
-      windows.main.show()
-    }, 100)
+    setTimeout(() => windows.main.show(), 100)
+
+    processArgv([ torrentId ])
   } else {
     argv.push(torrentId)
   }
@@ -133,7 +132,7 @@ function sliceArgv (argv) {
 }
 
 function processArgv (argv) {
-  var paths = []
+  var torrentIds = []
   argv.forEach(function (arg) {
     if (arg === '-n') {
       dialog.openSeedDirectory()
@@ -145,10 +144,10 @@ function processArgv (argv) {
       // Ignore OS X launchd "process serial number" argument
       // Issue: https://github.com/feross/webtorrent-desktop/issues/214
     } else {
-      paths.push(arg)
+      torrentIds.push(arg)
     }
   })
-  if (paths.length > 0) {
-    windows.main.dispatch('onOpen', paths)
+  if (torrentIds.length > 0) {
+    windows.main.dispatch('onOpen', torrentIds)
   }
 }

--- a/main/index.js
+++ b/main/index.js
@@ -55,7 +55,7 @@ function init () {
 
   ipc.init()
 
-  app.on('will-finish-launching', function () {
+  app.once('will-finish-launching', function () {
     crashReporter.init()
   })
 
@@ -70,7 +70,7 @@ function init () {
     setTimeout(delayedInit, config.DELAYED_INIT)
   })
 
-  app.on('ipcReady', function () {
+  app.once('ipcReady', function () {
     log('Command line args:', argv)
     processArgv(argv)
     console.timeEnd('init')
@@ -117,7 +117,6 @@ function onOpen (e, torrentId) {
 
 function onAppOpen (newArgv) {
   newArgv = sliceArgv(newArgv)
-  console.log(newArgv)
 
   if (app.ipcReady) {
     log('Second app instance opened, but was prevented:', newArgv)

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -25,13 +25,12 @@ var vlcProcess
 function init () {
   var ipc = electron.ipcMain
 
-  ipc.on('ipcReady', function (e) {
-    windows.main.show()
+  ipc.once('ipcReady', function (e) {
     app.ipcReady = true
     app.emit('ipcReady')
   })
 
-  ipc.on('ipcReadyWebTorrent', function (e) {
+  ipc.once('ipcReadyWebTorrent', function (e) {
     app.ipcReadyWebTorrent = true
     log('sending %d queued messages from the main win to the webtorrent window',
       messageQueueMainToWebTorrent.length)

--- a/main/log.js
+++ b/main/log.js
@@ -17,7 +17,7 @@ function log (...args) {
   if (app.ipcReady) {
     windows.main.send('log', ...args)
   } else {
-    app.on('ipcReady', () => windows.main.send('log', ...args))
+    app.once('ipcReady', () => windows.main.send('log', ...args))
   }
 }
 
@@ -25,6 +25,6 @@ function error (...args) {
   if (app.ipcReady) {
     windows.main.send('error', ...args)
   } else {
-    app.on('ipcReady', () => windows.main.send('error', ...args))
+    app.once('ipcReady', () => windows.main.send('error', ...args))
   }
 }

--- a/main/windows/about.js
+++ b/main/windows/about.js
@@ -31,7 +31,6 @@ function init () {
   // No menu on the About window
   win.setMenu(null)
 
-  // TODO: can this be removed?
   win.webContents.on('did-finish-load', function () {
     win.show()
   })

--- a/main/windows/main.js
+++ b/main/windows/main.js
@@ -36,7 +36,6 @@ function init () {
     icon: getIconPath(), // Window icon (Windows, Linux)
     minWidth: config.WINDOW_MIN_WIDTH,
     minHeight: config.WINDOW_MIN_HEIGHT,
-    show: false, // Hide window until renderer sends 'ipcReady'
     title: config.APP_WINDOW_TITLE,
     titleBarStyle: 'hidden-inset', // Hide title bar (OS X)
     useContentSize: true, // Specify web page size without OS chrome

--- a/renderer/main.css
+++ b/renderer/main.css
@@ -65,7 +65,7 @@ table {
   display: flex;
   flex-flow: column;
   background: rgb(40, 40, 40);
-  animation: fadein 1s;
+  animation: fadein 0.5s;
 }
 
 .app:not(.is-focused) {

--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -270,7 +270,7 @@ function getTorrentProgress () {
 function startServer (infoHash, index) {
   var torrent = client.get(infoHash)
   if (torrent.ready) startServerFromReadyTorrent(torrent, index)
-  else torrent.on('ready', () => startServerFromReadyTorrent(torrent, index))
+  else torrent.once('ready', () => startServerFromReadyTorrent(torrent, index))
 }
 
 function startServerFromReadyTorrent (torrent, index, cb) {


### PR DESCRIPTION
This should eliminate startup bugs caused by `ipcReady` being sent too eagerly from the renderer. I originally moved `ipcReady` to as early as possible in order to make the app launch faster.

But if we make the window show by default, instead of being hidden and waiting for `ipcReady`, then startup doesn't actually feel any slower.