### PR TITLE
Sketch: Remove torrent/data modal

### DIFF
--- a/renderer/main.css
+++ b/renderer/main.css
@@ -326,7 +326,6 @@ table {
 }
 
 .create-torrent input.torrent-is-private {
-  width: initial;
   margin: 0;
 }
 
@@ -404,7 +403,7 @@ button.button-raised:active {
  * OTHER FORM ELEMENT DEFAULTS
  */
 
-input {
+input[type='text'] {
   background: transparent;
   width: 300px;
   padding: 6px;

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -176,6 +176,13 @@ function dispatch (action, ...args) {
   if (action === 'openTorrentAddress') {
     state.modal = { id: 'open-torrent-address-modal' }
   }
+  if (action === 'confirmDeleteTorrent') {
+    state.modal = {
+      id: 'remove-torrent-modal',
+      infoHash: args[0],
+      deleteData: args[1]
+    }
+  }
   if (action === 'createTorrent') {
     createTorrent(args[0] /* options */)
   }
@@ -186,7 +193,7 @@ function dispatch (action, ...args) {
     toggleTorrent(args[0] /* infoHash */)
   }
   if (action === 'deleteTorrent') {
-    deleteTorrent(args[0] /* infoHash */)
+    deleteTorrent(args[0] /* infoHash */, args[1] /* deleteData */)
   }
   if (action === 'toggleSelectTorrent') {
     toggleSelectTorrent(args[0] /* infoHash */)
@@ -1172,12 +1179,12 @@ function openTorrentContextMenu (infoHash) {
 
   menu.append(new electron.remote.MenuItem({
     label: 'Remove From List',
-    click: () => deleteTorrent(torrentSummary.infoHash, false)
+    click: () => dispatch('confirmDeleteTorrent', torrentSummary.infoHash, false)
   }))
 
   menu.append(new electron.remote.MenuItem({
     label: 'Remove Data File',
-    click: () => deleteTorrent(torrentSummary.infoHash, true)
+    click: () => dispatch('confirmDeleteTorrent', torrentSummary.infoHash, true)
   }))
 
   menu.append(new electron.remote.MenuItem({

--- a/renderer/views/app.js
+++ b/renderer/views/app.js
@@ -12,6 +12,7 @@ var Views = {
 
 var Modals = {
   'open-torrent-address-modal': require('./open-torrent-address-modal'),
+  'remove-torrent-modal': require('./remove-torrent-modal'),
   'update-available-modal': require('./update-available-modal'),
   'unsupported-media-modal': require('./unsupported-media-modal')
 }

--- a/renderer/views/home.js
+++ b/renderer/views/home.js
@@ -172,7 +172,7 @@ function TorrentList (state) {
         <i
           class='icon delete'
           title='Remove torrent'
-          onclick=${dispatcher('deleteTorrent', infoHash)}>
+          onclick=${dispatcher('confirmDeleteTorrent', infoHash, false)}>
           close
         </i>
       </div>

--- a/renderer/views/remove-torrent-modal.js
+++ b/renderer/views/remove-torrent-modal.js
@@ -1,0 +1,26 @@
+module.exports = RemoveTorrentModal
+
+var {dispatch, dispatcher} = require('../lib/dispatcher')
+var hx = require('../lib/hx')
+
+function RemoveTorrentModal (state) {
+  var message = state.modal.deleteData
+    ? 'Are you sure you want to remove this torrent from the list and delete the data file?'
+    : 'Are you sure you want to remove this torrent from the list?'
+  var buttonText = state.modal.deleteData ? 'Remove Data' : 'Remove'
+
+  return hx`
+    <div>
+      <p><strong>${message}</strong></p>
+      <p class='float-right'>
+        <button class='button button-flat' onclick=${dispatcher('exitModal')}>Cancel</button>
+        <button class='button button-raised' onclick=${handleRemove}>${buttonText}</button>
+      </p>
+    </div>
+  `
+
+  function handleRemove () {
+    dispatch('deleteTorrent', state.modal.infoHash, state.modal.deleteData)
+    dispatch('exitModal')
+  }
+}


### PR DESCRIPTION
I think an option to remove all data, as requested in #560, is a good idea, so I made a simple modal for choosing this, like @demoneaux suggested.

![skaermbillede 2016-06-01 kl 16 23 58](https://cloud.githubusercontent.com/assets/8664776/15713400/986db226-2816-11e6-88a1-157bcf7af2c3.png)

Maybe this should just be an option in the right-click menu or preferences, but it might be nice for new users to have the choice at first? A cancel button could also be added?

Thoughts?