### PR TITLE
electron-prebuilt@1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deep-equal": "^1.0.1",
     "dlnacasts": "^0.1.0",
     "drag-drop": "^2.11.0",
-    "electron-prebuilt": "1.2.0",
+    "electron-prebuilt": "1.2.1",
     "fs-extra": "^0.27.0",
     "hyperx": "^2.0.2",
     "iso-639-1": "^1.2.1",


### PR DESCRIPTION
Full changelog here: https://github.com/electron/electron/releases/tag/v1.2.1

The main benefits to us is "Fix crash caused by calling `BrowserWindow.setAspectRatio(0)`"