### PR TITLE
Change step Forward/Backward shortcuts to match VLC's

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -217,13 +217,17 @@ function getMenuTemplate () {
         },
         {
           label: 'Step Forward',
-          accelerator: 'CmdOrCtrl+Alt+Right',
+          accelerator: process.platform === 'darwin'
+            ? 'CmdOrCtrl+Alt+Right'
+            : 'Alt+Right',
           click: () => windows.main.dispatch('skip', 1),
           enabled: false
         },
         {
           label: 'Step Backward',
-          accelerator: 'CmdOrCtrl+Alt+Left',
+          accelerator: process.platform === 'darwin'
+            ? 'CmdOrCtrl+Alt+Left'
+            : 'Alt+Left',
           click: () => windows.main.dispatch('skip', -1),
           enabled: false
         },


### PR DESCRIPTION
We got this feature idea from VLC, so let's align with the keyboard
shortcuts that they use :)

Closes #618.