### PR TITLE
Fix title in About Window

### DIFF
--- a/main/windows/about.js
+++ b/main/windows/about.js
@@ -22,6 +22,7 @@ function init () {
     resizable: false,
     show: false,
     skipTaskbar: true,
+    title: 'About ' + config.APP_WINDOW_TITLE,
     useContentSize: true,
     width: 300
   })


### PR DESCRIPTION
Shows up as 'Electron' on Windows