### PR TITLE
handle play/pause when window is hidden

### DIFF
--- a/renderer/main.js
+++ b/renderer/main.js
@@ -91,6 +91,9 @@ function onState (err, _state) {
   window.addEventListener('focus', onFocus)
   window.addEventListener('blur', onBlur)
 
+  // ...window visibility state.
+  document.addEventListener('webkitvisibilitychange', onVisibilityChange)
+
   sound.play('STARTUP')
 
   // Done! Ideally we want to get here < 500ms after the user clicks the app
@@ -360,6 +363,9 @@ function playPause () {
   } else {
     pause()
   }
+  // force rerendering if window is hidden,
+  // in order to bypass `raf` and play/pause media immediately
+  if (!state.window.isVisible) render(state)
 }
 
 function jumpToTime (time) {
@@ -1295,4 +1301,8 @@ function onFocus (e) {
 function onBlur () {
   state.window.isFocused = false
   update()
+}
+
+function onVisibilityChange () {
+  state.window.isVisible = !document.webkitHidden
 }


### PR DESCRIPTION
Fixes #598.

This could also be done using the already implemented `state.window.isFocused`, however I added a `webkitvisibilitychange` event listener, since we only need to force the render when the window is completely hidden and not just out of focus. The event does not fire often so I think this is reasonable.