### PR TITLE
[WIP] Playlists

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -127,7 +127,7 @@ function init () {
         if (!vlcProcess) return // Killed
         log('VLC exited with code ', code)
         if (code === 0) {
-          windows.main.dispatch('backToList')
+          windows.main.dispatch('vlcClosed')
         } else {
           windows.main.dispatch('vlcNotFound')
         }

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -63,6 +63,10 @@ function init () {
     shortcuts.onPlayerOpen()
   })
 
+  ipc.on('onPlayerUpdate', function (playing) {
+    menu.onPlayerUpdate(playing)
+  })
+
   ipc.on('onPlayerClose', function () {
     menu.onPlayerClose()
     shortcuts.onPlayerOpen()

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -63,8 +63,8 @@ function init () {
     shortcuts.onPlayerOpen()
   })
 
-  ipc.on('onPlayerUpdate', function (playing) {
-    menu.onPlayerUpdate(playing)
+  ipc.on('onPlayerUpdate', function (e, ...args) {
+    menu.onPlayerUpdate(...args)
   })
 
   ipc.on('onPlayerClose', function () {

--- a/main/menu.js
+++ b/main/menu.js
@@ -1,6 +1,7 @@
 module.exports = {
   init,
   onPlayerClose,
+  onPlayerUpdate,
   onPlayerOpen,
   onToggleAlwaysOnTop,
   onToggleFullScreen,
@@ -26,8 +27,8 @@ function init () {
 
 function onPlayerClose () {
   getMenuItem('Play/Pause').enabled = false
-  getMenuItem('Next Track').enabled = false
-  getMenuItem('Previous Track').enabled = false
+  getMenuItem('Skip Next').enabled = false
+  getMenuItem('Skip Previous').enabled = false
   getMenuItem('Increase Volume').enabled = false
   getMenuItem('Decrease Volume').enabled = false
   getMenuItem('Step Forward').enabled = false
@@ -37,10 +38,17 @@ function onPlayerClose () {
   getMenuItem('Add Subtitles File...').enabled = false
 }
 
+function onPlayerUpdate(playing) {
+  getMenuItem('Skip Next').enabled = (
+    playing.nextIndex === null ? false : true
+  )
+  getMenuItem('Skip Previous').enabled = (
+    playing.prevIndex === null ? false : true
+  )
+}
+
 function onPlayerOpen () {
   getMenuItem('Play/Pause').enabled = true
-  getMenuItem('Next Track').enabled = true
-  getMenuItem('Previous Track').enabled = true
   getMenuItem('Increase Volume').enabled = true
   getMenuItem('Decrease Volume').enabled = true
   getMenuItem('Step Forward').enabled = true
@@ -205,13 +213,13 @@ function getMenuTemplate () {
           type: 'separator'
         },
         {
-          label: 'Next Track',
+          label: 'Skip Next',
           accelerator: 'N',
           click: () => windows.main.dispatch('next'),
           enabled: false
         },
         {
-          label: 'Previous Track',
+          label: 'Skip Previous',
           accelerator: 'P',
           click: () => windows.main.dispatch('prev'),
           enabled: false

--- a/main/menu.js
+++ b/main/menu.js
@@ -29,8 +29,13 @@ function onPlayerClose () {
   getMenuItem('Play/Pause').enabled = false
   getMenuItem('Skip Next').enabled = false
   getMenuItem('Skip Previous').enabled = false
+
+  getMenuItem('Enable Shuffle').enabled = false
+  getMenuItem('Enable Shuffle').checked = false
+
   getMenuItem('Enable Repeat').enabled = false
   getMenuItem('Enable Repeat').checked = false
+
   getMenuItem('Increase Volume').enabled = false
   getMenuItem('Decrease Volume').enabled = false
   getMenuItem('Step Forward').enabled = false
@@ -43,11 +48,13 @@ function onPlayerClose () {
 function onPlayerUpdate (state) {
   getMenuItem('Skip Next').enabled = state.hasNext
   getMenuItem('Skip Previous').enabled = state.hasPrevious
+  getMenuItem('Enable Shuffle').checked = state.shuffle
   getMenuItem('Enable Repeat').checked = state.repeat
 }
 
 function onPlayerOpen () {
   getMenuItem('Play/Pause').enabled = true
+  getMenuItem('Enable Shuffle').enabled = true
   getMenuItem('Enable Repeat').enabled = true
   getMenuItem('Increase Volume').enabled = true
   getMenuItem('Decrease Volume').enabled = true
@@ -222,6 +229,16 @@ function getMenuTemplate () {
           label: 'Skip Previous',
           accelerator: 'P',
           click: () => windows.main.dispatch('prev'),
+          enabled: false
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Enable Shuffle',
+          type: 'checkbox',
+          checked: false,
+          click: () => windows.main.dispatch('toggleShuffle'),
           enabled: false
         },
         {

--- a/main/menu.js
+++ b/main/menu.js
@@ -26,6 +26,8 @@ function init () {
 
 function onPlayerClose () {
   getMenuItem('Play/Pause').enabled = false
+  getMenuItem('Next Track').enabled = false
+  getMenuItem('Previous Track').enabled = false
   getMenuItem('Increase Volume').enabled = false
   getMenuItem('Decrease Volume').enabled = false
   getMenuItem('Step Forward').enabled = false
@@ -37,6 +39,8 @@ function onPlayerClose () {
 
 function onPlayerOpen () {
   getMenuItem('Play/Pause').enabled = true
+  getMenuItem('Next Track').enabled = true
+  getMenuItem('Previous Track').enabled = true
   getMenuItem('Increase Volume').enabled = true
   getMenuItem('Decrease Volume').enabled = true
   getMenuItem('Step Forward').enabled = true
@@ -195,6 +199,21 @@ function getMenuTemplate () {
           label: 'Play/Pause',
           accelerator: 'Space',
           click: () => windows.main.dispatch('playPause'),
+          enabled: false
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Next Track',
+          accelerator: 'N',
+          click: () => windows.main.dispatch('next'),
+          enabled: false
+        },
+        {
+          label: 'Previous Track',
+          accelerator: 'P',
+          click: () => windows.main.dispatch('prev'),
           enabled: false
         },
         {

--- a/main/menu.js
+++ b/main/menu.js
@@ -29,6 +29,8 @@ function onPlayerClose () {
   getMenuItem('Play/Pause').enabled = false
   getMenuItem('Skip Next').enabled = false
   getMenuItem('Skip Previous').enabled = false
+  getMenuItem('Enable Repeat').enabled = false
+  getMenuItem('Enable Repeat').checked = false
   getMenuItem('Increase Volume').enabled = false
   getMenuItem('Decrease Volume').enabled = false
   getMenuItem('Step Forward').enabled = false
@@ -38,13 +40,15 @@ function onPlayerClose () {
   getMenuItem('Add Subtitles File...').enabled = false
 }
 
-function onPlayerUpdate (hasNext, hasPrevious) {
-  getMenuItem('Skip Next').enabled = hasNext
-  getMenuItem('Skip Previous').enabled = hasPrevious
+function onPlayerUpdate (state) {
+  getMenuItem('Skip Next').enabled = state.hasNext
+  getMenuItem('Skip Previous').enabled = state.hasPrevious
+  getMenuItem('Enable Repeat').checked = state.repeat
 }
 
 function onPlayerOpen () {
   getMenuItem('Play/Pause').enabled = true
+  getMenuItem('Enable Repeat').enabled = true
   getMenuItem('Increase Volume').enabled = true
   getMenuItem('Decrease Volume').enabled = true
   getMenuItem('Step Forward').enabled = true
@@ -218,6 +222,13 @@ function getMenuTemplate () {
           label: 'Skip Previous',
           accelerator: 'P',
           click: () => windows.main.dispatch('prev'),
+          enabled: false
+        },
+        {
+          label: 'Enable Repeat',
+          type: 'checkbox',
+          checked: false,
+          click: () => windows.main.dispatch('toggleRepeat'),
           enabled: false
         },
         {

--- a/main/menu.js
+++ b/main/menu.js
@@ -38,13 +38,9 @@ function onPlayerClose () {
   getMenuItem('Add Subtitles File...').enabled = false
 }
 
-function onPlayerUpdate(playing) {
-  getMenuItem('Skip Next').enabled = (
-    playing.nextIndex === null ? false : true
-  )
-  getMenuItem('Skip Previous').enabled = (
-    playing.prevIndex === null ? false : true
-  )
+function onPlayerUpdate (hasNext, hasPrevious) {
+  getMenuItem('Skip Next').enabled = hasNext
+  getMenuItem('Skip Previous').enabled = hasPrevious
 }
 
 function onPlayerOpen () {

--- a/main/shortcuts.js
+++ b/main/shortcuts.js
@@ -12,9 +12,19 @@ function onPlayerOpen () {
     'MediaPlayPause',
     () => windows.main.dispatch('playPause')
   )
+  electron.globalShortcut.register(
+    'MediaNextTrack',
+    () => windows.main.dispatch('next')
+  )
+  electron.globalShortcut.register(
+    'MediaPreviousTrack',
+    () => windows.main.dispatch('prev')
+  )
 }
 
 function onPlayerClose () {
   // Return the media key to the OS, so other apps can use it.
   electron.globalShortcut.unregister('MediaPlayPause')
+  electron.globalShortcut.unregister('MediaNext')
+  electron.globalShortcut.unregister('MediaPrev')
 }

--- a/renderer/lib/cast.js
+++ b/renderer/lib/cast.js
@@ -65,7 +65,7 @@ function chromecastPlayer (player) {
 
   function open () {
     var torrentSummary = state.saved.torrents.find((x) => x.infoHash === state.playing.infoHash)
-    player.play(state.server.networkURL, {
+    player.play(state.server.networkURL + '/' + state.playing.fileIndex, {
       type: 'video/mp4',
       title: config.APP_NAME + ' - ' + torrentSummary.name
     }, function (err) {
@@ -147,7 +147,7 @@ function airplayPlayer (player) {
   }
 
   function open () {
-    player.play(state.server.networkURL, function (err, res) {
+    player.play(state.server.networkURL + '/' + state.playing.fileIndex, function (err, res) {
       if (err) {
         state.playing.location = 'local'
         state.errors.push({
@@ -232,7 +232,7 @@ function dlnaPlayer (player) {
 
   function open () {
     var torrentSummary = state.saved.torrents.find((x) => x.infoHash === state.playing.infoHash)
-    player.play(state.server.networkURL, {
+    player.play(state.server.networkURL + '/' + state.playing.fileIndex, {
       type: 'video/mp4',
       title: config.APP_NAME + ' - ' + torrentSummary.name,
       seek: state.playing.currentTime > 10 ? state.playing.currentTime : 0

--- a/renderer/lib/errors.js
+++ b/renderer/lib/errors.js
@@ -1,8 +1,15 @@
 module.exports = {
-  UnplayableError
+  UnplayableTorrentError,
+  UnplayableFileError
 }
 
-function UnplayableError () {
+function UnplayableTorrentError () {
   this.message = 'Can\'t play any files in torrent'
 }
-UnplayableError.prototype = Error
+
+function UnplayableFileError () {
+  this.message = 'Can\'t play that file'
+}
+
+UnplayableTorrentError.prototype = Error
+UnplayableFileError.prototype = Error

--- a/renderer/lib/playlist.js
+++ b/renderer/lib/playlist.js
@@ -3,6 +3,7 @@ var TorrentPlayer = require('./torrent-player')
 module.exports = Playlist
 
 function Playlist (torrentSummary) {
+  this._infoHash = torrentSummary.infoHash
   this._position = 0
   this._tracks = extractTracks(torrentSummary)
   this._order = range(0, this._tracks.length)
@@ -14,6 +15,10 @@ function Playlist (torrentSummary) {
 // =============================================================================
 // Public methods
 // =============================================================================
+
+Playlist.prototype.getInfoHash = function () {
+  return this._infoHash
+}
 
 Playlist.prototype.getTracks = function () {
   return this._tracks
@@ -62,10 +67,10 @@ Playlist.prototype.toggleRepeat = function (value) {
   this._repeat = (value === undefined ? !this._repeat : value)
 }
 
-Playlist.prototype.jumpTo = function (infoHash, fileIndex) {
+Playlist.prototype.jumpToFile = function (fileIndex) {
   this.setPosition(this._order.findIndex((i) => {
     let track = this._tracks[i]
-    return track.infoHash === infoHash && track.fileIndex === fileIndex
+    return track.fileIndex === fileIndex
   }))
   return this.getCurrent()
 }
@@ -124,7 +129,6 @@ function extractTracks (torrentSummary) {
       return 0
     })
     .map((object) => ({
-      infoHash: torrentSummary.infoHash,
       fileIndex: object.index,
       type: TorrentPlayer.isVideo(object.file) ? 'video'
           : TorrentPlayer.isAudio(object.file) ? 'audio'

--- a/renderer/lib/playlist.js
+++ b/renderer/lib/playlist.js
@@ -1,0 +1,73 @@
+var TorrentPlayer = require('./torrent-player')
+
+module.exports = Playlist
+
+function Playlist (torrentSummary) {
+  this._position = 0
+  this._tracks = extractTracks(torrentSummary)
+}
+
+Playlist.prototype.getTracks = function () {
+  return this._tracks
+}
+
+Playlist.prototype.hasNext = function () {
+  return this._position + 1 < this._tracks.length
+}
+
+Playlist.prototype.hasPrevious = function () {
+  return this._position > 0
+}
+
+Playlist.prototype.next = function () {
+  if (this.hasNext()) {
+    this._position++
+    return this.getCurrent()
+  }
+}
+
+Playlist.prototype.previous = function () {
+  if (this.hasPrevious()) {
+    this._position--
+    return this.getCurrent()
+  }
+}
+
+Playlist.prototype.jumpTo = function (infoHash, fileIndex) {
+  this.setPosition(this._tracks.findIndex(
+    (track) => track.infoHash === infoHash && track.fileIndex === fileIndex
+  ))
+  return this.getCurrent()
+}
+
+Playlist.prototype.getCurrent = function () {
+  var position = this.getPosition()
+  return position === undefined ? undefined : this._tracks[position]
+}
+
+Playlist.prototype.getPosition = function () {
+  if (this._position >= 0 && this._position < this._tracks.length) {
+    return this._position
+  } else return undefined
+}
+
+Playlist.prototype.setPosition = function (position) {
+  this._position = position
+}
+
+function extractTracks (torrentSummary) {
+  return torrentSummary.files.map((file, index) => ({ file, index }))
+    .filter((object) => TorrentPlayer.isPlayable(object.file))
+    .sort(function (a, b) {
+      if (a.file.name < b.file.name) return -1
+      if (b.file.name < a.file.name) return 1
+      return 0
+    })
+    .map((object) => ({
+      infoHash: torrentSummary.infoHash,
+      fileIndex: object.index,
+      type: TorrentPlayer.isVideo(object.file) ? 'video'
+          : TorrentPlayer.isAudio(object.file) ? 'audio'
+          : 'other'
+    }))
+}

--- a/renderer/lib/playlist.js
+++ b/renderer/lib/playlist.js
@@ -5,6 +5,7 @@ module.exports = Playlist
 function Playlist (torrentSummary) {
   this._position = 0
   this._tracks = extractTracks(torrentSummary)
+  this._repeat = false
 }
 
 Playlist.prototype.getTracks = function () {
@@ -12,25 +13,37 @@ Playlist.prototype.getTracks = function () {
 }
 
 Playlist.prototype.hasNext = function () {
-  return this._position + 1 < this._tracks.length
+  return !this._tracks.length ? false
+        : this._repeat ? true
+        : this._position + 1 < this._tracks.length
 }
 
 Playlist.prototype.hasPrevious = function () {
-  return this._position > 0
+  return !this._tracks.length ? false
+        : this._repeat ? true
+        : this._position > 0
 }
 
 Playlist.prototype.next = function () {
   if (this.hasNext()) {
-    this._position++
+    this._position = mod(this._position + 1, this._tracks.length)
     return this.getCurrent()
   }
 }
 
 Playlist.prototype.previous = function () {
   if (this.hasPrevious()) {
-    this._position--
+    this._position = mod(this._position - 1, this._tracks.length)
     return this.getCurrent()
   }
+}
+
+Playlist.prototype.repeatEnabled = function () {
+  return this._repeat
+}
+
+Playlist.prototype.toggleRepeat = function (value) {
+  this._repeat = (value === undefined ? !this._repeat : value)
 }
 
 Playlist.prototype.jumpTo = function (infoHash, fileIndex) {
@@ -70,4 +83,8 @@ function extractTracks (torrentSummary) {
           : TorrentPlayer.isAudio(object.file) ? 'audio'
           : 'other'
     }))
+}
+
+function mod (a, b) {
+  return ((a % b) + b) % b
 }

--- a/renderer/lib/state.js
+++ b/renderer/lib/state.js
@@ -75,8 +75,6 @@ function getDefaultPlayState () {
   return {
     infoHash: null, /* the info hash of the torrent we're playing */
     fileIndex: null, /* the zero-based index within the torrent */
-    nextIndex: null, /* the index of the next playable file (if any) */
-    prevIndex: null, /* the index of the previous playable file (if any) */
     location: 'local', /* 'local', 'chromecast', 'airplay' */
     type: null, /* 'audio' or 'video', could be 'other' if ever support eg streaming to VLC */
     currentTime: 0, /* seconds */

--- a/renderer/lib/state.js
+++ b/renderer/lib/state.js
@@ -74,6 +74,8 @@ function getDefaultPlayState () {
   return {
     infoHash: null, /* the info hash of the torrent we're playing */
     fileIndex: null, /* the zero-based index within the torrent */
+    nextIndex: null, /* the index of the next playable file (if any) */
+    prevIndex: null, /* the index of the previous playable file (if any) */
     location: 'local', /* 'local', 'chromecast', 'airplay' */
     type: null, /* 'audio' or 'video', could be 'other' if ever support eg streaming to VLC */
     currentTime: 0, /* seconds */

--- a/renderer/lib/state.js
+++ b/renderer/lib/state.js
@@ -32,6 +32,7 @@ function getDefaultState () {
     },
     selectedInfoHash: null, /* the torrent we've selected to view details. see state.torrents */
     playing: getDefaultPlayState(), /* the media (audio or video) that we're currently playing */
+    playlist: null,
     devices: { /* playback devices like Chromecast and AppleTV */
       airplay: null, /* airplay client. finds and manages AppleTVs */
       chromecast: null /* chromecast client. finds and manages Chromecasts */

--- a/renderer/lib/torrent-player.js
+++ b/renderer/lib/torrent-player.js
@@ -2,7 +2,9 @@ module.exports = {
   isPlayable,
   isVideo,
   isAudio,
-  isPlayableTorrent
+  isPlayableTorrent,
+  nextIndex,
+  prevIndex
 }
 
 var path = require('path')
@@ -41,4 +43,14 @@ function isAudio (file) {
 
 function isPlayableTorrent (torrentSummary) {
   return torrentSummary.files && torrentSummary.files.some(isPlayable)
+}
+
+function nextIndex (torrentSummary, index) {
+  var diff = 1 + torrentSummary.files.slice(index + 1).map(isPlayable).indexOf(true)
+  return diff > 0 ? index + diff : null
+}
+
+function prevIndex (torrentSummary, index) {
+  var diff = 1 + torrentSummary.files.slice(0, index).reverse().map(isPlayable).indexOf(true)
+  return diff > 0 ? index - diff : null
 }

--- a/renderer/lib/torrent-player.js
+++ b/renderer/lib/torrent-player.js
@@ -2,9 +2,7 @@ module.exports = {
   isPlayable,
   isVideo,
   isAudio,
-  isPlayableTorrent,
-  getPlaylist,
-  getNeighbors
+  isPlayableTorrent
 }
 
 var path = require('path')
@@ -43,25 +41,4 @@ function isAudio (file) {
 
 function isPlayableTorrent (torrentSummary) {
   return torrentSummary.files && torrentSummary.files.some(isPlayable)
-}
-
-function getPlaylist (torrentSummary) {
-  return torrentSummary.files.filter(isPlayable)
-    .map((file, index) => ({ file, index }))
-    .sort(function (a, b) {
-      if (a.file.name < b.file.name) return -1
-      if (b.file.name < a.file.name) return 1
-      return 0
-    })
-    .map((object) => object.index)
-}
-
-function getNeighbors (torrentSummary, fileIndex) {
-  var playlist = getPlaylist(torrentSummary)
-  var index = playlist.findIndex((i) => i === fileIndex)
-
-  return {
-    prev: index > 0 ? playlist[index - 1] : null,
-    next: index < playlist.length ? playlist[index + 1] : null
-  }
 }

--- a/renderer/lib/torrent-player.js
+++ b/renderer/lib/torrent-player.js
@@ -3,8 +3,8 @@ module.exports = {
   isVideo,
   isAudio,
   isPlayableTorrent,
-  nextIndex,
-  prevIndex
+  getPlaylist,
+  getNeighbors
 }
 
 var path = require('path')
@@ -45,12 +45,23 @@ function isPlayableTorrent (torrentSummary) {
   return torrentSummary.files && torrentSummary.files.some(isPlayable)
 }
 
-function nextIndex (torrentSummary, index) {
-  var diff = 1 + torrentSummary.files.slice(index + 1).map(isPlayable).indexOf(true)
-  return diff > 0 ? index + diff : null
+function getPlaylist (torrentSummary) {
+  return torrentSummary.files.filter(isPlayable)
+    .map((file, index) => ({ file, index }))
+    .sort(function (a, b) {
+      if (a.file.name < b.file.name) return -1
+      if (b.file.name < a.file.name) return 1
+      return 0
+    })
+    .map((object) => object.index)
 }
 
-function prevIndex (torrentSummary, index) {
-  var diff = 1 + torrentSummary.files.slice(0, index).reverse().map(isPlayable).indexOf(true)
-  return diff > 0 ? index - diff : null
+function getNeighbors (torrentSummary, fileIndex) {
+  var playlist = getPlaylist(torrentSummary)
+  var index = playlist.findIndex((i) => i === fileIndex)
+
+  return {
+    prev: index > 0 ? playlist[index - 1] : null,
+    next: index < playlist.length ? playlist[index + 1] : null
+  }
 }

--- a/renderer/main.css
+++ b/renderer/main.css
@@ -834,6 +834,7 @@ body.drag .app::after {
 }
 
 .player .controls .closed-caption.active,
+.player .controls .repeat.active,
 .player .controls .device.active {
   color: #9af;
 }

--- a/renderer/main.css
+++ b/renderer/main.css
@@ -835,6 +835,7 @@ body.drag .app::after {
 
 .player .controls .closed-caption.active,
 .player .controls .repeat.active,
+.player .controls .shuffle.active,
 .player .controls .device.active {
   color: #9af;
 }

--- a/renderer/main.css
+++ b/renderer/main.css
@@ -724,7 +724,21 @@ body.drag .app::after {
   opacity: 1;
 }
 
-.player .controls .play-pause {
+.player .controls .icon.prev {
+  font-size: 28px;
+  margin-top: 5px;
+  margin-right: 10px;
+  margin-left: 15px;
+}
+
+.player .controls .icon.play-pause {
+  font-size: 28px;
+  margin-top: 5px;
+  margin-right: 10px;
+  margin-left: 15px;
+}
+
+.player .controls .icon.next {
   font-size: 28px;
   margin-top: 5px;
   margin-right: 10px;

--- a/renderer/main.css
+++ b/renderer/main.css
@@ -724,6 +724,10 @@ body.drag .app::after {
   opacity: 1;
 }
 
+.player .controls .icon.disabled {
+  opacity: 0.3;
+}
+
 .player .controls .icon.prev {
   font-size: 28px;
   margin-top: 5px;

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -262,6 +262,9 @@ function dispatch (action, ...args) {
   if (action === 'toggleSubtitlesMenu') {
     toggleSubtitlesMenu()
   }
+  if (action === 'toggleShuffle') {
+    toggleShuffle(args[0] /* optional bool */)
+  }
   if (action === 'toggleRepeat') {
     toggleRepeat(args[0] /* optional bool */)
   }
@@ -402,13 +405,26 @@ function prev () {
   }
 }
 
+function toggleShuffle (value) {
+  if (state.playlist) {
+    state.playlist.toggleShuffle(value)
+    ipcRenderer.send('onPlayerUpdate', {
+      hasNext: state.playlist.hasNext(),
+      hasPrevious: state.playlist.hasPrevious(),
+      repeat: state.playlist.repeatEnabled(),
+      shuffle: state.playlist.shuffleEnabled()
+    })
+  }
+}
+
 function toggleRepeat (value) {
   if (state.playlist) {
     state.playlist.toggleRepeat(value)
     ipcRenderer.send('onPlayerUpdate', {
       hasNext: state.playlist.hasNext(),
       hasPrevious: state.playlist.hasPrevious(),
-      repeat: state.playlist.repeatEnabled()
+      repeat: state.playlist.repeatEnabled(),
+      shuffle: state.playlist.shuffleEnabled()
     })
   }
 }
@@ -1069,7 +1085,8 @@ function updatePlayer (cb) {
   ipcRenderer.send('onPlayerUpdate', {
     hasNext: state.playlist.hasNext(),
     hasPrevious: state.playlist.hasPrevious(),
-    repeat: state.playlist.repeatEnabled()
+    repeat: state.playlist.repeatEnabled(),
+    shuffle: state.playlist.shuffleEnabled()
   })
   cb()
   update()

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -294,6 +294,14 @@ function dispatch (action, ...args) {
     ipcRenderer.send('vlcPlay', state.server.localURL + '/' + state.playing.fileIndex)
     state.playing.location = 'vlc'
   }
+  if (action === 'vlcClosed') {
+    if (state.playlist.hasNext()) {
+      state.playing.location = 'local'
+      next()
+    } else {
+      backToList()
+    }
+  }
   if (action === 'vlcNotFound') {
     if (state.modal && state.modal.id === 'unsupported-media-modal') {
       state.modal.vlcNotFound = true

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -291,7 +291,7 @@ function dispatch (action, ...args) {
     state.playing.mouseStationarySince = new Date().getTime()
   }
   if (action === 'vlcPlay') {
-    ipcRenderer.send('vlcPlay', state.server.localURL)
+    ipcRenderer.send('vlcPlay', state.server.localURL + '/' + state.playing.fileIndex)
     state.playing.location = 'vlc'
   }
   if (action === 'vlcNotFound') {

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -995,14 +995,14 @@ function torrentServerRunning (serverInfo) {
 function playFile (infoHash, index) {
   if (state.location.url() === 'player') {
     play()
-    state.playlist.jumpTo(infoHash, index)
+    state.playlist.jumpToFile(index)
     updatePlayer(callback)
   } else {
     var torrentSummary = getTorrentSummary(infoHash)
     var playlist = new Playlist(torrentSummary)
 
     if (index === undefined) index = torrentSummary.mostRecentFileIndex
-    if (index !== undefined) playlist.jumpTo(infoHash, index)
+    if (index !== undefined) playlist.jumpToFile(index)
 
     state.location.go({
       url: 'player',
@@ -1027,7 +1027,7 @@ function updatePlayer (cb) {
     return cb(new Error('Can\'t play that file'))
   }
 
-  var torrentSummary = getTorrentSummary(track.infoHash)
+  var torrentSummary = getTorrentSummary(state.playlist.getInfoHash())
   var fileSummary = torrentSummary.files[track.fileIndex]
 
   torrentSummary.mostRecentFileIndex = track.fileIndex
@@ -1073,7 +1073,7 @@ function openPlayer (playlist, cb) {
   var track = playlist.getCurrent()
   if (track === undefined) return cb(new errors.UnplayableError())
 
-  var torrentSummary = getTorrentSummary(track.infoHash)
+  var torrentSummary = getTorrentSummary(playlist.getInfoHash())
 
   state.playing.infoHash = torrentSummary.infoHash
 

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -1021,8 +1021,11 @@ function openPlayerFromActiveTorrent (torrentSummary, index, timeout, cb) {
   // update state
   state.playing.infoHash = torrentSummary.infoHash
   state.playing.fileIndex = index
-  state.playing.nextIndex = TorrentPlayer.nextIndex(torrentSummary, index)
-  state.playing.prevIndex = TorrentPlayer.prevIndex(torrentSummary, index)
+
+  var neighbors = TorrentPlayer.getNeighbors(torrentSummary, index)
+  state.playing.nextIndex = neighbors.next
+  state.playing.prevIndex = neighbors.prev
+
   state.playing.type = TorrentPlayer.isVideo(fileSummary) ? 'video'
     : TorrentPlayer.isAudio(fileSummary) ? 'audio'
     : 'other'

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -222,6 +222,12 @@ function dispatch (action, ...args) {
   if (action === 'playPause') {
     playPause()
   }
+  if (action === 'next') {
+    nextFile()
+  }
+  if (action === 'prev') {
+    prevFile()
+  }
   if (action === 'play') {
     playFile(args[0] /* infoHash */, args[1] /* index */)
   }
@@ -365,6 +371,18 @@ function playPause () {
   // force rerendering if window is hidden,
   // in order to bypass `raf` and play/pause media immediately
   if (!state.window.isVisible) render(state)
+}
+
+function nextFile () {
+  if (state.playing.nextIndex !== null) {
+    playFile(state.playing.infoHash, state.playing.nextIndex)
+  }
+}
+
+function prevFile () {
+  if (state.playing.prevIndex !== null) {
+    playFile(state.playing.infoHash, state.playing.prevIndex)
+  }
 }
 
 function jumpToTime (time) {
@@ -1003,6 +1021,8 @@ function openPlayerFromActiveTorrent (torrentSummary, index, timeout, cb) {
   // update state
   state.playing.infoHash = torrentSummary.infoHash
   state.playing.fileIndex = index
+  state.playing.nextIndex = TorrentPlayer.nextIndex(torrentSummary, index)
+  state.playing.prevIndex = TorrentPlayer.prevIndex(torrentSummary, index)
   state.playing.type = TorrentPlayer.isVideo(fileSummary) ? 'video'
     : TorrentPlayer.isAudio(fileSummary) ? 'audio'
     : 'other'

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -54,7 +54,13 @@ function onState (err, _state) {
   state = _state
 
   // Add first page to location history
-  state.location.go({ url: 'home' })
+  state.location.go({
+    url: 'home',
+    onbeforeload: function (cb) {
+      state.window.title = config.APP_WINDOW_TITLE
+      cb()
+    }
+  })
 
   // Restart everything we were torrenting last time the app ran
   resumeTorrents()
@@ -309,7 +315,6 @@ function dispatch (action, ...args) {
       onbeforeunload: function (cb) {
         // save state after preferences
         savePreferences()
-        state.window.title = config.APP_WINDOW_TITLE
         cb()
       }
     })
@@ -1131,7 +1136,6 @@ function closePlayer (cb) {
   if (state.playing.location === 'vlc') {
     ipcRenderer.send('vlcQuit')
   }
-  state.window.title = config.APP_WINDOW_TITLE
   // Lets save volume for later
   state.previousVolume = state.playing.volume
 

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -1009,7 +1009,7 @@ function playFile (infoHash, index) {
     if (index === undefined) index = pickFileToPlay(torrentSummary.files)
     if (index === undefined) return onError(new errors.UnplayableError())
 
-    playlist.setPosition(index)
+    playlist.jumpTo(infoHash, index)
 
     state.location.go({
       url: 'player',

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -1042,6 +1042,8 @@ function updatePlayer (resume, cb) {
     if (fraction < 0.9 && secondsLeft > 10) {
       state.playing.jumpToTime = fileSummary.currentTime
     }
+  } else {
+    state.playing.jumpToTime = 0
   }
 
   // if it's audio, parse out the metadata (artist, title, etc)

--- a/renderer/views/home.js
+++ b/renderer/views/home.js
@@ -138,10 +138,10 @@ function TorrentList (state) {
     // of the play button, unless already showing a spinner there:
     var positionElem
     var willShowSpinner = torrentSummary.playStatus === 'requested'
-    var defaultFile = torrentSummary.files &&
-      torrentSummary.files[torrentSummary.defaultPlayFileIndex]
-    if (defaultFile && defaultFile.currentTime && !willShowSpinner) {
-      var fraction = defaultFile.currentTime / defaultFile.duration
+    var mostRecentFile = torrentSummary.files &&
+    torrentSummary.files[torrentSummary.mostRecentFileIndex]
+    if (mostRecentFile && mostRecentFile.currentTime && !willShowSpinner) {
+      var fraction = mostRecentFile.currentTime / mostRecentFile.duration
       positionElem = renderRadialProgressBar(fraction, 'radial-progress-large')
       playClass = 'resume-position'
     }

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -339,6 +339,7 @@ function renderPlayerControls (state) {
       ? 'active'
       : ''
   var repeatClass = state.playlist.repeatEnabled() ? 'active' : ''
+  var shuffleClass = state.playlist.shuffleEnabled() ? 'active' : ''
 
   var elements = []
 
@@ -405,6 +406,14 @@ function renderPlayerControls (state) {
       class='${repeatClass}'
       onclick=${dispatcher('toggleRepeat')}>
       repeat
+    </i>
+  `)
+
+  elements.push(hx`
+    <i.icon.shuffle.float-right
+      class='${shuffleClass}'
+      onclick=${dispatcher('toggleShuffle')}>
+      shuffle
     </i>
   `)
 

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -43,7 +43,7 @@ function renderMedia (state) {
       mediaElement.play()
     }
     // When the user clicks or drags on the progress bar, jump to that position
-    if (state.playing.jumpToTime) {
+    if (state.playing.jumpToTime != null) {
       mediaElement.currentTime = state.playing.jumpToTime
       state.playing.jumpToTime = null
     }

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -338,6 +338,8 @@ function renderPlayerControls (state) {
     : state.playing.subtitles.selectedIndex >= 0
       ? 'active'
       : ''
+  var prevClass = state.playlist.hasPrevious() ? '' : 'disabled'
+  var nextClass = state.playlist.hasNext() ? '' : 'disabled'
   var repeatClass = state.playlist.repeatEnabled() ? 'active' : ''
   var shuffleClass = state.playlist.shuffleEnabled() ? 'active' : ''
 
@@ -360,13 +362,13 @@ function renderPlayerControls (state) {
     </div>
   `)
 
-  if (state.playlist.hasPrevious()) {
-    elements.push(hx`
-      <i class='icon prev float-left' onclick=${dispatcher('prev')}>
-        skip_previous
-      </i>
-    `)
-  }
+  elements.push(hx`
+    <i.icon.prev.float-left
+      class='${prevClass}'
+      onclick=${dispatcher('prev')}>
+      skip_previous
+    </i>
+  `)
 
   elements.push(hx`
     <i class='icon play-pause float-left' onclick=${dispatcher('playPause')}>
@@ -374,13 +376,13 @@ function renderPlayerControls (state) {
     </i>
   `)
 
-  if (state.playlist.hasNext()) {
-    elements.push(hx`
-      <i class='icon next float-left' onclick=${dispatcher('next')}>
-        skip_next
-      </i>
-    `)
-  }
+  elements.push(hx`
+    <i.icon.next.float-left
+      class='${nextClass}'
+      onclick=${dispatcher('next')}>
+      skip_next
+    </i>
+  `)
 
   elements.push(hx`
     <i

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -95,7 +95,7 @@ function renderMedia (state) {
   // Create the <audio> or <video> tag
   var mediaTag = hx`
     <div
-      src='${state.server.localURL}'
+      src='${state.server.localURL + '/' + state.playing.fileIndex}'
       ondblclick=${dispatcher('toggleFullScreen')}
       onloadedmetadata=${onLoadedMetadata}
       onended=${onEnded}

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -338,6 +338,7 @@ function renderPlayerControls (state) {
     : state.playing.subtitles.selectedIndex >= 0
       ? 'active'
       : ''
+  var repeatClass = state.playlist.repeatEnabled() ? 'active' : ''
 
   var elements = []
 
@@ -398,6 +399,14 @@ function renderPlayerControls (state) {
       </i>
     `)
   }
+
+  elements.push(hx`
+    <i.icon.repeat.float-right
+      class='${repeatClass}'
+      onclick=${dispatcher('toggleRepeat')}>
+      repeat
+    </i>
+  `)
 
   // If we've detected a Chromecast or AppleTV, the user can play video there
   var isOnChromecast = state.playing.location.startsWith('chromecast')

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -339,36 +339,54 @@ function renderPlayerControls (state) {
       ? 'active'
       : ''
 
-  var elements = [
-    hx`
-      <div class='playback-bar'>
-        ${renderLoadingBar(state)}
-        <div
-          class='playback-cursor'
-          style=${playbackCursorStyle}>
-        </div>
-        <div
-          class='scrub-bar'
-          draggable='true'
-          ondragstart=${handleDragStart}
-          onclick=${handleScrub},
-          ondrag=${handleScrub}>
-        </div>
+  var elements = []
+
+  elements.push(hx`
+    <div class='playback-bar'>
+      ${renderLoadingBar(state)}
+      <div
+        class='playback-cursor'
+        style=${playbackCursorStyle}>
       </div>
-    `,
-    hx`
-      <i class='icon play-pause float-left' onclick=${dispatcher('playPause')}>
-        ${state.playing.isPaused ? 'play_arrow' : 'pause'}
+      <div
+        class='scrub-bar'
+        draggable='true'
+        ondragstart=${handleDragStart}
+        onclick=${handleScrub},
+        ondrag=${handleScrub}>
+      </div>
+    </div>
+  `)
+
+  if (state.playing.prevIndex !== null) {
+    elements.push(hx`
+      <i class='icon play-pause float-left' onclick=${dispatcher('prev')}>
+        skip_previous
       </i>
-    `,
-    hx`
-      <i
-        class='icon fullscreen float-right'
-        onclick=${dispatcher('toggleFullScreen')}>
-        ${state.window.isFullScreen ? 'fullscreen_exit' : 'fullscreen'}
+    `)
+  }
+
+  elements.push(hx`
+    <i class='icon play-pause float-left' onclick=${dispatcher('playPause')}>
+      ${state.playing.isPaused ? 'play_arrow' : 'pause'}
+    </i>
+  `)
+
+  if (state.playing.nextIndex !== null) {
+    elements.push(hx`
+      <i class='icon play-pause float-left' onclick=${dispatcher('next')}>
+        skip_next
       </i>
-    `
-  ]
+    `)
+  }
+
+  elements.push(hx`
+    <i
+      class='icon fullscreen float-right'
+      onclick=${dispatcher('toggleFullScreen')}>
+      ${state.window.isFullScreen ? 'fullscreen_exit' : 'fullscreen'}
+    </i>
+  `)
 
   if (state.playing.type === 'video') {
     // show closed captions icon

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -135,7 +135,7 @@ function renderMedia (state) {
       dispatch('next')
     } else {
       // When the last video completes, pause the video instead of looping
-      state.playing.paused = true
+      state.playing.isPaused = true
     }
   }
 
@@ -360,7 +360,7 @@ function renderPlayerControls (state) {
 
   if (state.playlist.hasPrevious()) {
     elements.push(hx`
-      <i class='icon play-pause float-left' onclick=${dispatcher('prev')}>
+      <i class='icon prev float-left' onclick=${dispatcher('prev')}>
         skip_previous
       </i>
     `)
@@ -374,7 +374,7 @@ function renderPlayerControls (state) {
 
   if (state.playlist.hasNext()) {
     elements.push(hx`
-      <i class='icon play-pause float-left' onclick=${dispatcher('next')}>
+      <i class='icon next float-left' onclick=${dispatcher('next')}>
         skip_next
       </i>
     `)

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -130,9 +130,13 @@ function renderMedia (state) {
     dispatch('setDimensions', dimensions)
   }
 
-  // When the video completes, pause the video instead of looping
   function onEnded (e) {
-    state.playing.isPaused = true
+    if (state.playing.nextIndex !== null) {
+      dispatch('next')
+    } else {
+      // When the last video completes, pause the video instead of looping
+      state.playing.paused = true
+    }
   }
 
   function onCanPlay (e) {

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -131,7 +131,7 @@ function renderMedia (state) {
   }
 
   function onEnded (e) {
-    if (state.playing.nextIndex !== null) {
+    if (state.playlist.hasNext()) {
       dispatch('next')
     } else {
       // When the last video completes, pause the video instead of looping
@@ -358,7 +358,7 @@ function renderPlayerControls (state) {
     </div>
   `)
 
-  if (state.playing.prevIndex !== null) {
+  if (state.playlist.hasPrevious()) {
     elements.push(hx`
       <i class='icon play-pause float-left' onclick=${dispatcher('prev')}>
         skip_previous
@@ -372,7 +372,7 @@ function renderPlayerControls (state) {
     </i>
   `)
 
-  if (state.playing.nextIndex !== null) {
+  if (state.playlist.hasNext()) {
     elements.push(hx`
       <i class='icon play-pause float-left' onclick=${dispatcher('next')}>
         skip_next

--- a/renderer/webtorrent.js
+++ b/renderer/webtorrent.js
@@ -54,8 +54,8 @@ function init () {
     generateTorrentPoster(torrentKey))
   ipc.on('wt-get-audio-metadata', (e, infoHash, index) =>
     getAudioMetadata(infoHash, index))
-  ipc.on('wt-start-server', (e, infoHash, index) =>
-    startServer(infoHash, index))
+  ipc.on('wt-start-server', (e, infoHash) =>
+    startServer(infoHash))
   ipc.on('wt-stop-server', (e) =>
     stopServer())
   ipc.on('wt-select-files', (e, infoHash, selections) =>
@@ -267,20 +267,20 @@ function getTorrentProgress () {
   }
 }
 
-function startServer (infoHash, index) {
+function startServer (infoHash) {
   var torrent = client.get(infoHash)
-  if (torrent.ready) startServerFromReadyTorrent(torrent, index)
-  else torrent.once('ready', () => startServerFromReadyTorrent(torrent, index))
+  if (torrent.ready) startServerFromReadyTorrent(torrent)
+  else torrent.once('ready', () => startServerFromReadyTorrent(torrent))
 }
 
-function startServerFromReadyTorrent (torrent, index, cb) {
+function startServerFromReadyTorrent (torrent, cb) {
   if (server) return
 
   // start the streaming torrent-to-http server
   server = torrent.createServer()
   server.listen(0, function () {
     var port = server.address().port
-    var urlSuffix = ':' + port + '/' + index
+    var urlSuffix = ':' + port
     var info = {
       torrentKey: torrent.key,
       localURL: 'http://localhost' + urlSuffix,


### PR DESCRIPTION
Add playlists, as proposed in #123.

![image](https://cloud.githubusercontent.com/assets/2529619/16269659/8a0860f4-3893-11e6-97b4-da0b715bc1de.png)

Features:
-
- All torrents are now treated as playlists (for one-file torrents, that is a one-file playlist)
- Playback initially starts at the first file (so `defaultPlayFileIndex` has to go), then we store index of the most recently played file, so that we can pick up where we left off later on
- Control playback through on-screen controls, menu or dedicated media keys
- _Shuffle_ and _repeat_ options


Known issues:
-
- Error thrown when returning from preferences view to the player. See #653

```
rendering error: Cannot read property 'startPiece' of undefined
	TypeError: Cannot read property 'startPiece' of undefined
    at renderLoadingBar (D:\Workspace\webtorrent-desktop\renderer\views\player.js:605:24)
    at renderPlayerControls (D:\Workspace\webtorrent-desktop\renderer\views\player.js:347:9)
    at Object.Player (D:\Workspace\webtorrent-desktop\renderer\views\player.js:22:9)
    at getView (D:\Workspace\webtorrent-desktop\renderer\views\app.js:81:20)
    at App (D:\Workspace\webtorrent-desktop\renderer\views\app.js:44:30)
    at render (file:///D:/Workspace/webtorrent-desktop/renderer/main.js:122:12)
    at redraw (D:\Workspace\webtorrent-desktop\node_modules\main-loop\index.js:65:23)
    at D:\Workspace\webtorrent-desktop\node_modules\main-loop\node_modules\raf\index.js:72:10
```