### PR TITLE
Seeding: sort files by path

### DIFF
--- a/renderer/main.js
+++ b/renderer/main.js
@@ -756,6 +756,7 @@ function findFilesRecursive (paths, cb) {
       findFilesRecursive([path], function (fileObjs) {
         ret = ret.concat(fileObjs)
         if (++numComplete === paths.length) {
+          ret.sort((a, b) => a.path < b.path ? -1 : a.path > b.path)
           cb(ret)
         }
       })


### PR DESCRIPTION
Fixes a bug where you could create duplicate torrents by adding the same folder multiple times, because the file order & therefore the infohash was nondeterministic