### PR TITLE
Only send telemetry from production

### DIFF
--- a/renderer/lib/telemetry.js
+++ b/renderer/lib/telemetry.js
@@ -30,7 +30,13 @@ function init (state) {
   telemetry.system = getSystemInfo()
   telemetry.approxNumTorrents = getApproxNumTorrents(state)
 
-  postToServer(telemetry)
+  if (config.IS_PRODUCTION) {
+    postToServer()
+  } else {
+    // Development: telemetry used only for local debugging
+    // Empty uncaught errors, etc at the start of every run
+    reset()
+  }
 }
 
 function reset () {


### PR DESCRIPTION
Also fix a bug where Remove Data File doesn't work when the first file in the torrent is in a subfolder.