### PR TITLE
Open in VLC

### DIFF
--- a/config.js
+++ b/config.js
@@ -75,8 +75,7 @@ module.exports = {
   WINDOW_WEBTORRENT: 'file://' + path.join(__dirname, 'renderer', 'webtorrent.html'),
 
   WINDOW_MIN_HEIGHT: 38 + (120 * 2), // header height + 2 torrents
-  WINDOW_MIN_WIDTH: 425,
-  OPEN_IN_VLC: false
+  WINDOW_MIN_WIDTH: 425
 }
 
 function getConfigPath () {

--- a/config.js
+++ b/config.js
@@ -75,7 +75,8 @@ module.exports = {
   WINDOW_WEBTORRENT: 'file://' + path.join(__dirname, 'renderer', 'webtorrent.html'),
 
   WINDOW_MIN_HEIGHT: 38 + (120 * 2), // header height + 2 torrents
-  WINDOW_MIN_WIDTH: 425
+  WINDOW_MIN_WIDTH: 425,
+  OPEN_IN_VLC: false
 }
 
 function getConfigPath () {

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -59,6 +59,8 @@ function init () {
    * Events
    */
 
+  ipc.on('onState', (...args) => menu.onState(...args))
+
   ipc.on('onPlayerOpen', function () {
     menu.onPlayerOpen()
     shortcuts.onPlayerOpen()

--- a/main/menu.js
+++ b/main/menu.js
@@ -59,6 +59,10 @@ function onToggleFullScreen (flag) {
   getMenuItem('Full Screen').checked = flag
 }
 
+function onToggleOpenInVlc (flag) {
+  getMenuItem('Open in VLC').checked = flag
+}
+
 function onWindowBlur () {
   getMenuItem('Full Screen').enabled = false
   getMenuItem('Float on Top').enabled = false
@@ -258,6 +262,12 @@ function getMenuTemplate () {
           label: 'Add Subtitles File...',
           click: () => windows.main.dispatch('openSubtitles'),
           enabled: false
+        },
+        {
+          label: 'Open in VLC',
+          type: 'checkbox',
+          click: () => windows.main.dispatch('toggleOpenInVlc', getMenuItem('Open in VLC')),
+          enabled: true
         }
       ]
     },

--- a/main/menu.js
+++ b/main/menu.js
@@ -31,7 +31,7 @@ function init () {
 function onState (err, _state) {
   if (err) return onError(err)
   state = _state
-  
+
   // Refresh menu
   menu = electron.Menu.buildFromTemplate(getMenuTemplate())
   electron.Menu.setApplicationMenu(menu)

--- a/main/menu.js
+++ b/main/menu.js
@@ -17,10 +17,22 @@ var dialog = require('./dialog')
 var shell = require('./shell')
 var windows = require('./windows')
 var thumbnail = require('./thumbnail')
+var State = require('../renderer/lib/state')
 
-var menu
+var menu, state
 
 function init () {
+  menu = electron.Menu.buildFromTemplate(getMenuTemplate())
+  electron.Menu.setApplicationMenu(menu)
+
+  State.load(onState)
+}
+
+function onState (err, _state) {
+  if (err) return onError(err)
+  state = _state
+  
+  // Refresh menu
   menu = electron.Menu.buildFromTemplate(getMenuTemplate())
   electron.Menu.setApplicationMenu(menu)
 }
@@ -263,7 +275,8 @@ function getMenuTemplate () {
           label: 'Open in VLC',
           type: 'checkbox',
           click: () => windows.main.dispatch('toggleOpenInVlc', getMenuItem('Open in VLC')),
-          enabled: true
+          enabled: true,
+          checked: state && state.saved.openInVlc
         }
       ]
     },

--- a/main/menu.js
+++ b/main/menu.js
@@ -59,10 +59,6 @@ function onToggleFullScreen (flag) {
   getMenuItem('Full Screen').checked = flag
 }
 
-function onToggleOpenInVlc (flag) {
-  getMenuItem('Open in VLC').checked = flag
-}
-
 function onWindowBlur () {
   getMenuItem('Full Screen').enabled = false
   getMenuItem('Float on Top').enabled = false

--- a/main/menu.js
+++ b/main/menu.js
@@ -37,6 +37,14 @@ function onState (err, _state) {
   electron.Menu.setApplicationMenu(menu)
 }
 
+function onError (err) {
+  console.error(err.stack || err)
+  state.errors.push({
+    time: new Date().getTime(),
+    message: err.message || err
+  })
+}
+
 function onPlayerClose () {
   getMenuItem('Play/Pause').enabled = false
   getMenuItem('Increase Volume').enabled = false

--- a/main/menu.js
+++ b/main/menu.js
@@ -5,7 +5,8 @@ module.exports = {
   onToggleAlwaysOnTop,
   onToggleFullScreen,
   onWindowBlur,
-  onWindowFocus
+  onWindowFocus,
+  onState
 }
 
 var electron = require('electron')
@@ -17,18 +18,16 @@ var dialog = require('./dialog')
 var shell = require('./shell')
 var windows = require('./windows')
 var thumbnail = require('./thumbnail')
-var State = require('../renderer/lib/state')
 
 var menu, state
 
 function init () {
   menu = electron.Menu.buildFromTemplate(getMenuTemplate())
   electron.Menu.setApplicationMenu(menu)
-
-  State.load(onState)
 }
 
-function onState (err, _state) {
+function onState (e, err, _state) {
+  console.log('[ MENU ]--> GOT STATE')
   if (err) return onError(err)
   state = _state
 

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -53,6 +53,9 @@ function onState (err, _state) {
   if (err) return onError(err)
   state = _state
 
+  // send loaded state to main process
+  ipcRenderer.send('onState', err, _state)
+
   // Add first page to location history
   state.location.go({ url: 'home' })
 

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -154,11 +154,11 @@ function updateElectron () {
 function toggleOpenInVlc (menuItem) {
   var flag = menuItem.checked
   console.log(`toggleOpenInVlc ${flag}`)
-  config.OPEN_IN_VLC = flag
+  state.saved.openInVlc = flag;
 }
 
 function getOpenInVlc () {
-  return config.OPEN_IN_VLC
+  return state.saved.openInVlc
 }
 
 // Events from the UI never modify state directly. Instead they call dispatch()

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -167,7 +167,7 @@ function dispatch (action, ...args) {
   if (!['mediaMouseMoved', 'mediaTimeUpdate'].includes(action)) {
     console.log('dispatch: %s %o', action, args)
   }
-  if (action === 'toggleOpenInVlc') {
+  if (action === 'toggleOpenInVlc') {
     toggleOpenInVlc(args[0])
   }
   if (action === 'onOpen') {
@@ -1079,7 +1079,7 @@ function openPlayerFromActiveTorrent (torrentSummary, index, timeout, cb) {
       dispatch('vlcPlay')
       update()
       cb()
-      return;
+      return
     }
 
     // otherwise, play the video

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -154,7 +154,7 @@ function updateElectron () {
 function toggleOpenInVlc (menuItem) {
   var flag = menuItem.checked
   console.log(`toggleOpenInVlc ${flag}`)
-  state.saved.openInVlc = flag;
+  state.saved.openInVlc = flag
 }
 
 function getOpenInVlc () {

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -151,6 +151,16 @@ function updateElectron () {
   }
 }
 
+function toggleOpenInVlc(menuItem) {
+  var flag = menuItem.checked;
+  console.log(`toggleOpenInVlc ${flag}`);
+  config.OPEN_IN_VLC = flag;
+}
+
+function getOpenInVlc() {
+  return config.OPEN_IN_VLC;
+}
+
 // Events from the UI never modify state directly. Instead they call dispatch()
 function dispatch (action, ...args) {
   // Log dispatch calls, for debugging
@@ -158,6 +168,9 @@ function dispatch (action, ...args) {
     console.log('dispatch: %s %o', action, args)
   }
 
+  if (action === 'toggleOpenInVlc') {
+    toggleOpenInVlc(args[0]);
+  }
   if (action === 'onOpen') {
     onOpen(args[0] /* files */)
   }
@@ -1060,6 +1073,17 @@ function openPlayerFromActiveTorrent (torrentSummary, index, timeout, cb) {
       ipcRenderer.send('wt-stop-server')
       return update()
     }
+
+    //------------------------------------------------------ 
+    // play in VLC if set as default player (Menu: Playback / Open in VLC)
+    if (getOpenInVlc()) {
+      console.log('-- OPEN IN VLC', torrentSummary);
+      dispatch('vlcPlay');
+      update()
+      cb()
+      return;
+    }
+    //------------------------------------------------------
 
     // otherwise, play the video
     state.window.title = torrentSummary.files[state.playing.fileIndex].name

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -151,14 +151,14 @@ function updateElectron () {
   }
 }
 
-function toggleOpenInVlc(menuItem) {
-  var flag = menuItem.checked;
-  console.log(`toggleOpenInVlc ${flag}`);
-  config.OPEN_IN_VLC = flag;
+function toggleOpenInVlc (menuItem) {
+  var flag = menuItem.checked
+  console.log(`toggleOpenInVlc ${flag}`)
+  config.OPEN_IN_VLC = flag
 }
 
-function getOpenInVlc() {
-  return config.OPEN_IN_VLC;
+function getOpenInVlc () {
+  return config.OPEN_IN_VLC
 }
 
 // Events from the UI never modify state directly. Instead they call dispatch()
@@ -167,9 +167,8 @@ function dispatch (action, ...args) {
   if (!['mediaMouseMoved', 'mediaTimeUpdate'].includes(action)) {
     console.log('dispatch: %s %o', action, args)
   }
-
   if (action === 'toggleOpenInVlc') {
-    toggleOpenInVlc(args[0]);
+    toggleOpenInVlc(args[0])
   }
   if (action === 'onOpen') {
     onOpen(args[0] /* files */)
@@ -1074,16 +1073,14 @@ function openPlayerFromActiveTorrent (torrentSummary, index, timeout, cb) {
       return update()
     }
 
-    //------------------------------------------------------ 
     // play in VLC if set as default player (Menu: Playback / Open in VLC)
     if (getOpenInVlc()) {
-      console.log('-- OPEN IN VLC', torrentSummary);
-      dispatch('vlcPlay');
+      console.log('-- OPEN IN VLC', torrentSummary)
+      dispatch('vlcPlay')
       update()
       cb()
       return;
     }
-    //------------------------------------------------------
 
     // otherwise, play the video
     state.window.title = torrentSummary.files[state.playing.fileIndex].name

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -413,7 +413,7 @@ function renderPlayerControls (state) {
   var buttonIcons = {
     'chromecast': {true: 'cast_connected', false: 'cast'},
     'airplay': {true: 'airplay', false: 'airplay'},
-    'dnla': {true: 'tv', false: 'tv'}
+    'dlna': {true: 'tv', false: 'tv'}
   }
   castTypes.forEach(function (castType) {
     // Do we show this button (eg. the Chromecast button) at all?


### PR DESCRIPTION
Added new checkbox menu item: _Playback / Open in VLC_.
While _Open in VLC_ is checked all video playback will be sent to VLC.
This is really useful if you prefer playing video in VLC instead of the embedded player.