### PR TITLE
Fix state.playing.jumpToTime behavior

### DIFF
--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -43,7 +43,7 @@ function renderMedia (state) {
       mediaElement.play()
     }
     // When the user clicks or drags on the progress bar, jump to that position
-    if (state.playing.jumpToTime) {
+    if (state.playing.jumpToTime != null) {
       mediaElement.currentTime = state.playing.jumpToTime
       state.playing.jumpToTime = null
     }


### PR DESCRIPTION
Previously, `state.playing.jumpToTime = 0` didn't do anything. This commit fixes that.