### PR TITLE
[Urgent] Fix error in renderer/views/player.js

### DIFF
--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -413,7 +413,7 @@ function renderPlayerControls (state) {
   var buttonIcons = {
     'chromecast': {true: 'cast_connected', false: 'cast'},
     'airplay': {true: 'airplay', false: 'airplay'},
-    'dnla': {true: 'tv', false: 'tv'}
+    'dlna': {true: 'tv', false: 'tv'}
   }
   castTypes.forEach(function (castType) {
     // Do we show this button (eg. the Chromecast button) at all?


### PR DESCRIPTION
Previously, the following error was thrown on player open:

```
rendering error: Cannot read property 'false' of undefined
	TypeError: Cannot read property 'false' of undefined
    at D:\Workspace\webtorrent-desktop\renderer\views\player.js:439:43
    at Array.forEach (native)
    at renderPlayerControls (D:\Workspace\webtorrent-desktop\renderer\views\player.js:418:13)
    at Object.Player (D:\Workspace\webtorrent-desktop\renderer\views\player.js:22:9)
    at getView (D:\Workspace\webtorrent-desktop\renderer\views\app.js:81:20)
    at App (D:\Workspace\webtorrent-desktop\renderer\views\app.js:44:30)
    at render (file:///D:/Workspace/webtorrent-desktop/renderer/main.js:126:12)
    at redraw (D:\Workspace\webtorrent-desktop\node_modules\main-loop\index.js:65:23)
    at D:\Workspace\webtorrent-desktop\node_modules\main-loop\node_modules\raf\index.js:72:10
```

It is fixed now.