### PR TITLE
Save selected subtitle

### DIFF
--- a/renderer/controllers/playback-controller.js
+++ b/renderer/controllers/playback-controller.js
@@ -224,6 +224,11 @@ function openPlayerFromActiveTorrent (state, torrentSummary, index, timeout, cb)
   // if it's video, check for subtitles files that are done downloading
   dispatch('checkForSubtitles')
 
+  // enable previously selected subtitle track
+  if (fileSummary.selectedSubtitle) {
+    dispatch('addSubtitles', [fileSummary.selectedSubtitle], true)
+  }
+
   ipcRenderer.send('wt-start-server', torrentSummary.infoHash, index)
   ipcRenderer.once('wt-server-' + torrentSummary.infoHash, (e, info) => {
     clearTimeout(timeout)

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -199,6 +199,7 @@ const dispatchHandlers = {
   'selectSubtitle': (index) => controllers.subtitles.selectSubtitle(index),
   'toggleSubtitlesMenu': () => controllers.subtitles.toggleSubtitlesMenu(),
   'checkForSubtitles': () => controllers.subtitles.checkForSubtitles(),
+  'addSubtitles': (files, autoSelect) => controllers.subtitles.addSubtitles(files, autoSelect),
 
   // Local media: <video>, <audio>, VLC
   'mediaStalled': () => controllers.media.mediaStalled(),

--- a/renderer/views/player.js
+++ b/renderer/views/player.js
@@ -73,6 +73,15 @@ function renderMedia (state) {
     var file = state.getPlayingFileSummary()
     file.currentTime = state.playing.currentTime = mediaElement.currentTime
     file.duration = state.playing.duration = mediaElement.duration
+
+    // Save selected subtitle
+    if (state.playing.subtitles.selectedIndex !== -1) {
+      var index = state.playing.subtitles.selectedIndex
+      file.selectedSubtitle = state.playing.subtitles.tracks[index].filePath
+    } else if (file.selectedSubtitle != null) {
+      delete file.selectedSubtitle
+    }
+
     state.playing.volume = mediaElement.volume
   }
 


### PR DESCRIPTION
Fixes #701.
The selected subtitle index is stored in the same way as the current time of the playing file. It might be overkill to do this on every render, but I could not see other obvious places to put it, since subtitles can be added/selected in multiple ways.