### PR TITLE
Improve error logging

### DIFF
--- a/renderer/lib/telemetry.js
+++ b/renderer/lib/telemetry.js
@@ -123,12 +123,12 @@ function logUncaughtError (procName, err) {
   if (!telemetry) return
 
   var message, stack
-  if (typeof err === 'string') {
-    message = err
-    stack = ''
-  } else {
+  if (err instanceof Error) {
     message = err.message
     stack = err.stack
+  } else {
+    message = String(err)
+    stack = ''
   }
 
   // We need to POST the telemetry object, make sure it stays < 100kb

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -109,7 +109,7 @@ function onState (err, _state) {
 
   // Log uncaught JS errors
   window.addEventListener('error',
-    (e) => telemetry.logUncaughtError('window', e.error), true)
+    (e) => telemetry.logUncaughtError('window', e.error || e.target), true)
 
   // Done! Ideally we want to get here < 500ms after the user clicks the app
   sound.play('STARTUP')


### PR DESCRIPTION
When I tried to play an unsupported video the uncaught error was `undefined` for some reason.