### PR TITLE
Fix unhandled 'error' dispatch

### DIFF
--- a/renderer/controllers/torrent-list-controller.js
+++ b/renderer/controllers/torrent-list-controller.js
@@ -207,7 +207,7 @@ function findFilesRecursive (paths, cb) {
 
   var fileOrFolder = paths[0]
   fs.stat(fileOrFolder, function (err, stat) {
-    if (err) return dispatch('onError', err)
+    if (err) return dispatch('error', err)
 
     // Files: return name, path, and size
     if (!stat.isDirectory()) {
@@ -222,7 +222,7 @@ function findFilesRecursive (paths, cb) {
     // Folders: recurse, make a list of all the files
     var folderPath = fileOrFolder
     fs.readdir(folderPath, function (err, fileNames) {
-      if (err) return dispatch('onError', err)
+      if (err) return dispatch('error', err)
       var paths = fileNames.map((fileName) => path.join(folderPath, fileName))
       findFilesRecursive(paths, cb)
     })
@@ -257,9 +257,9 @@ function saveTorrentFileAs (torrentSummary) {
   electron.remote.dialog.showSaveDialog(electron.remote.getCurrentWindow(), opts, function (savePath) {
     var torrentPath = TorrentSummary.getTorrentPath(torrentSummary)
     fs.readFile(torrentPath, function (err, torrentFile) {
-      if (err) return dispatch('onError', err)
+      if (err) return dispatch('error', err)
       fs.writeFile(savePath, torrentFile, function (err) {
-        if (err) return dispatch('onError', err)
+        if (err) return dispatch('error', err)
       })
     })
   })

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -237,7 +237,7 @@ const dispatchHandlers = {
 
   // Everything else
   'onOpen': (files) => onOpen(files),
-  'onError': (err) => onError(err),
+  'error': (err) => onError(err),
   'uncaughtError': (proc, err) => telemetry.logUncaughtError(proc, err),
   'saveState': () => State.save(state)
 }

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -231,13 +231,13 @@ const dispatchHandlers = {
   'forward': () => state.location.forward(),
 
   // Controlling the window
-  'setDimensions': (dimensions) => setDimensions(dimensions),
+  'setDimensions': setDimensions,
   'toggleFullScreen': (setTo) => ipcRenderer.send('toggleFullScreen', setTo),
   'setTitle': (title) => { state.window.title = title },
 
   // Everything else
-  'onOpen': (files) => onOpen(files),
-  'error': (err) => onError(err),
+  'onOpen': onOpen,
+  'error': onError,
   'uncaughtError': (proc, err) => telemetry.logUncaughtError(proc, err),
   'saveState': () => State.save(state)
 }


### PR DESCRIPTION
Fix unhandled 'error' dispatch used by the `subtitles-controller` and `playback-controller`, and be consistent in the `torrent-list-controller`. 