### PR TITLE
Remove torrent data (single file / folder)

### DIFF
--- a/renderer/controllers/torrent-list-controller.js
+++ b/renderer/controllers/torrent-list-controller.js
@@ -229,14 +229,11 @@ function findFilesRecursive (paths, cb) {
   })
 }
 
-// Delete all files in a torren
+// Delete all files in a torrent
 function moveItemToTrash (torrentSummary) {
-  // TODO: delete directories, not just files
-  torrentSummary.files.forEach(function (file) {
-    var filePath = path.join(torrentSummary.path, file.path)
-    console.log('DEBUG DELETING ' + filePath)
-    ipcRenderer.send('moveItemToTrash', filePath)
-  })
+  var filePath = path.join(torrentSummary.path, torrentSummary.files[0].path.split('/')[0])
+  console.log('DEBUG DELETING ' + filePath)
+  ipcRenderer.send('moveItemToTrash', filePath)
 }
 
 function showItemInFolder (torrentSummary) {


### PR DESCRIPTION
Right now we move every single file from the torrent to the trash bin one at a time, making it hard to undo the delete because the files are not organized in a folder anymore.

With this PR we always delete a single file or the folder containing the torrent data. I know I already proposed this fix before, but I think it is a better alternative.

@dcposch mentioned that if you drag multiple files (not a folder) to the window a new torrent is created where the directory (common ancestor) might be the users download folder (or something worse). In this case removing data would delete the entire downloads folder. To avoid this I propose we only allow creating torrents from a single file or a single folder. This is consistent with the `Create New Torrent` menu item and is also how Transmission does.

Alternatively we could copy the files to a new folder when the torrent is created?