### PR TITLE
Electron: Updates for Electron 1.2.8

### DIFF
--- a/src/main/dock.js
+++ b/src/main/dock.js
@@ -30,12 +30,11 @@ function downloadFinished (path) {
 }
 
 /**
- * Display string in dock badging area. (OS X)
+ * Display a counter badge for the app. (OS X, Linux)
  */
-function setBadge (text) {
-  if (!app.dock) return
-  log(`setBadge: ${text}`)
-  app.dock.setBadge(String(text))
+function setBadge (count) {
+  log(`setBadge: ${count}`)
+  app.setBadgeCount(Number(count))
 }
 
 function getMenuTemplate () {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -107,6 +107,15 @@ function getMenuTemplate () {
       label: 'Edit',
       submenu: [
         {
+          role: 'undo'
+        },
+        {
+          role: 'redo'
+        },
+        {
+          type: 'separator'
+        },
+        {
           role: 'cut'
         },
         {
@@ -115,6 +124,9 @@ function getMenuTemplate () {
         {
           label: 'Paste Torrent Address',
           role: 'paste'
+        },
+        {
+          role: 'delete'
         },
         {
           role: 'selectall'

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -319,9 +319,7 @@ function getMenuTemplate () {
           type: 'separator'
         },
         {
-          label: 'Quit',
-          accelerator: 'Command+Q',
-          click: () => app.quit()
+          role: 'quit'
         }
       ]
     })

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -99,10 +99,6 @@ function getMenuTemplate () {
           type: 'separator'
         },
         {
-          label: process.platform === 'win32'
-            ? 'Close'
-            : 'Close Window',
-          accelerator: 'CmdOrCtrl+W',
           role: 'close'
         }
       ]
@@ -111,23 +107,16 @@ function getMenuTemplate () {
       label: 'Edit',
       submenu: [
         {
-          label: 'Cut',
-          accelerator: 'CmdOrCtrl+X',
           role: 'cut'
         },
         {
-          label: 'Copy',
-          accelerator: 'CmdOrCtrl+C',
           role: 'copy'
         },
         {
           label: 'Paste Torrent Address',
-          accelerator: 'CmdOrCtrl+V',
           role: 'paste'
         },
         {
-          label: 'Select All',
-          accelerator: 'CmdOrCtrl+A',
           role: 'selectall'
         },
         {
@@ -285,7 +274,6 @@ function getMenuTemplate () {
       label: config.APP_NAME,
       submenu: [
         {
-          label: 'About ' + config.APP_NAME,
           role: 'about'
         },
         {
@@ -300,7 +288,6 @@ function getMenuTemplate () {
           type: 'separator'
         },
         {
-          label: 'Services',
           role: 'services',
           submenu: []
         },
@@ -308,17 +295,12 @@ function getMenuTemplate () {
           type: 'separator'
         },
         {
-          label: 'Hide ' + config.APP_NAME,
-          accelerator: 'Command+H',
           role: 'hide'
         },
         {
-          label: 'Hide Others',
-          accelerator: 'Command+Alt+H',
           role: 'hideothers'
         },
         {
-          label: 'Show All',
           role: 'unhide'
         },
         {
@@ -334,19 +316,15 @@ function getMenuTemplate () {
 
     // Add Window menu (OS X)
     template.splice(5, 0, {
-      label: 'Window',
       role: 'window',
       submenu: [
         {
-          label: 'Minimize',
-          accelerator: 'CmdOrCtrl+M',
           role: 'minimize'
         },
         {
           type: 'separator'
         },
         {
-          label: 'Bring All to Front',
           role: 'front'
         }
       ]

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -146,7 +146,7 @@ function updateElectron () {
   }
   if (state.dock.badge !== state.prev.badge) {
     state.prev.badge = state.dock.badge
-    ipcRenderer.send('setBadge', state.dock.badge || '')
+    ipcRenderer.send('setBadge', state.dock.badge || 0)
   }
 }
 


### PR DESCRIPTION
Followup PR to #738.

- Electron: Use default labels and accelerators
- macOS: add missing Edit menu roles
- Use 'quit' role
- Linux: Support showing badge count

Please review: @mathiasvr 