### PR TITLE
electron-prebuilt@1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deep-equal": "^1.0.1",
     "dlnacasts": "^0.1.0",
     "drag-drop": "^2.11.0",
-    "electron-prebuilt": "1.2.8",
+    "electron-prebuilt": "1.3.0",
     "fs-extra": "^0.30.0",
     "iso-639-1": "^1.2.1",
     "languagedetect": "^1.1.1",


### PR DESCRIPTION
Another Electron was just released. Let's bump from 1.2.8 to 1.3.0.

Changelog:

- Upgrade to Chrome 52
- Update to Node.js 6.3.0