### PR TITLE
Set peer ID to start with "-WD-"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "drag-drop": "^2.11.0",
     "electron-prebuilt": "1.3.0",
     "fs-extra": "^0.30.0",
+    "hat": "0.0.3",
     "iso-639-1": "^1.2.1",
     "languagedetect": "^1.1.1",
     "musicmetadata": "^2.0.2",

--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -41,7 +41,7 @@ var VERSION = require('../../package.json').version
  */
 var VERSION_STR = VERSION.match(/([0-9]+)/g)
   .slice(0, 2)
-  .map(function (v) { return zeroFill(2, v) })
+  .map((v) => zeroFill(2, v))
   .join('')
 
 /**


### PR DESCRIPTION
To distinguish WebTorrent Desktop (WD) from WebTorrent in the browser
(WW).

See the spec:

http://www.bittorrent.org/beps/bep_0020.html
https://wiki.theory.org/BitTorrentSpecification