### PR TITLE
Replace deprecated `react-tools` with `babel`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "react"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
-  "presets": [
-    "react"
+  "plugins": [
+    "syntax-jsx",
+    "transform-react-jsx"
   ]
 }

--- a/bin/check-deps.js
+++ b/bin/check-deps.js
@@ -45,7 +45,13 @@ var BUILT_IN_ELECTRON_MODULES = [ 'electron' ]
 
 var BUILT_IN_DEPS = [].concat(BUILT_IN_NODE_MODULES, BUILT_IN_ELECTRON_MODULES)
 
-var EXECUTABLE_DEPS = ['gh-release', 'standard', 'babel-cli', 'babel-preset-react']
+var EXECUTABLE_DEPS = [
+  'gh-release',
+  'standard',
+  'babel-cli',
+  'babel-plugin-syntax-jsx',
+  'babel-plugin-transform-react-jsx'
+]
 
 main()
 

--- a/bin/check-deps.js
+++ b/bin/check-deps.js
@@ -45,7 +45,7 @@ var BUILT_IN_ELECTRON_MODULES = [ 'electron' ]
 
 var BUILT_IN_DEPS = [].concat(BUILT_IN_NODE_MODULES, BUILT_IN_ELECTRON_MODULES)
 
-var EXECUTABLE_DEPS = ['gh-release', 'standard', 'react-tools']
+var EXECUTABLE_DEPS = ['gh-release', 'standard', 'babel-cli', 'babel-preset-react']
 
 main()
 

--- a/bin/package.js
+++ b/bin/package.js
@@ -19,6 +19,7 @@ var config = require('../src/config')
 var pkg = require('../package.json')
 
 var BUILD_NAME = config.APP_NAME + '-v' + config.APP_VERSION
+var BUILD_PATH = path.join(config.ROOT_PATH, 'build')
 var DIST_PATH = path.join(config.ROOT_PATH, 'dist')
 
 var argv = minimist(process.argv.slice(2), {
@@ -36,6 +37,12 @@ var argv = minimist(process.argv.slice(2), {
 
 function build () {
   rimraf.sync(DIST_PATH)
+  rimraf.sync(BUILD_PATH)
+
+  console.log('Babel: Building JSX...')
+  cp.execSync('npm run build', { NODE_ENV: 'production', stdio: 'inherit' })
+  console.log('Babel: Built JSX.')
+
   var platform = argv._[0]
   if (platform === 'darwin') {
     buildDarwin(printDone)

--- a/bin/package.js
+++ b/bin/package.js
@@ -89,7 +89,7 @@ var all = {
 
   // Pattern which specifies which files to ignore when copying files to create the
   // package(s).
-  ignore: /^\/dist|\/(appveyor.yml|\.appveyor.yml|\.github|appdmg|AUTHORS|CONTRIBUTORS|bench|benchmark|benchmark\.js|bin|bower\.json|component\.json|coverage|doc|docs|docs\.mli|dragdrop\.min\.js|example|examples|example\.html|example\.js|externs|ipaddr\.min\.js|Makefile|min|minimist|perf|rusha|simplepeer\.min\.js|simplewebsocket\.min\.js|static\/screenshot\.png|test|tests|test\.js|tests\.js|webtorrent\.min\.js|\.[^\/]*|.*\.md|.*\.markdown)$/,
+  ignore: /^\/src|^\/dist|\/(appveyor.yml|\.appveyor.yml|\.github|appdmg|AUTHORS|CONTRIBUTORS|bench|benchmark|benchmark\.js|bin|bower\.json|component\.json|coverage|doc|docs|docs\.mli|dragdrop\.min\.js|example|examples|example\.html|example\.js|externs|ipaddr\.min\.js|Makefile|min|minimist|perf|rusha|simplepeer\.min\.js|simplewebsocket\.min\.js|static\/screenshot\.png|test|tests|test\.js|tests\.js|webtorrent\.min\.js|\.[^\/]*|.*\.md|.*\.markdown)$/,
 
   // The application name.
   name: config.APP_NAME,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "zero-fill": "^2.2.3"
   },
   "devDependencies": {
+    "babel-cli": "^6.11.4",
+    "babel-preset-react": "^6.11.1",
     "cross-zip": "^2.0.1",
     "electron-osx-sign": "^0.3.0",
     "electron-packager": "^7.0.0",
@@ -55,7 +57,6 @@
     "nobin-debian-installer": "^0.0.10",
     "open": "0.0.5",
     "plist": "^1.2.0",
-    "react-tools": "^0.13.3",
     "rimraf": "^2.5.2",
     "run-series": "^1.1.4",
     "standard": "^7.0.0"
@@ -85,10 +86,11 @@
     "url": "git://github.com/feross/webtorrent-desktop.git"
   },
   "scripts": {
+    "build": "babel src -d build",
     "clean": "node ./bin/clean.js",
     "open-config": "node ./bin/open-config.js",
-    "package": "rimraf build/ && jsx --es6module src/ build/ && node ./bin/package.js",
-    "start": "jsx --es6module src/ build/ && electron .",
+    "package": "node ./bin/package.js",
+    "start": "npm run build && electron .",
     "test": "standard && node ./bin/check-deps.js",
     "update-authors": "./bin/update-authors.sh"
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
-    "babel-preset-react": "^6.11.1",
+    "babel-plugin-syntax-jsx": "^6.13.0",
+    "babel-plugin-transform-react-jsx": "^6.8.0",
     "cross-zip": "^2.0.1",
     "electron-osx-sign": "^0.3.0",
     "electron-packager": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "url": "git://github.com/feross/webtorrent-desktop.git"
   },
   "scripts": {
-    "build": "babel src -d build",
+    "build": "babel --quiet src --out-dir build",
     "clean": "node ./bin/clean.js",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "clean": "node ./bin/clean.js",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
+    "prepublish": "npm run build",
     "start": "npm run build && electron .",
     "test": "standard && node ./bin/check-deps.js",
     "update-authors": "./bin/update-authors.sh"

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -23,7 +23,11 @@ var windows = require('./windows')
 var shouldQuit = false
 var argv = sliceArgv(process.argv)
 
-if (!argv.includes('--dev')) process.env.NODE_ENV = 'production'
+if (config.IS_PRODUCTION) {
+  // When Electron is running in produdtion mode (packaged app), then run React
+  // in production mode too.
+  process.env.NODE_ENV = 'production'
+}
 
 if (process.platform === 'win32') {
   shouldQuit = squirrelWin32.handleEvent(argv[0])

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -24,7 +24,7 @@ var shouldQuit = false
 var argv = sliceArgv(process.argv)
 
 if (config.IS_PRODUCTION) {
-  // When Electron is running in produdtion mode (packaged app), then run React
+  // When Electron is running in production mode (packaged app), then run React
   // in production mode too.
   process.env.NODE_ENV = 'production'
 }


### PR DESCRIPTION
- Switch to babel, since react-tools has been deprecated since June 12, 2015. See https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html

- Move babel command to "npm run build"

- Move commands for package into "bin/package.js"