### PR TITLE
Fix screen stacking bug

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -61,14 +61,14 @@ function init () {
    */
 
   ipc.on('onPlayerOpen', function () {
-    menu.onPlayerOpen()
+    menu.setPlayerOpen(true)
     powerSaveBlocker.enable()
     shortcuts.enable()
     thumbar.enable()
   })
 
   ipc.on('onPlayerClose', function () {
-    menu.onPlayerClose()
+    menu.setPlayerOpen(false)
     powerSaveBlocker.disable()
     shortcuts.disable()
     thumbar.disable()
@@ -112,6 +112,7 @@ function init () {
   ipc.on('setTitle', (e, ...args) => main.setTitle(...args))
   ipc.on('show', () => main.show())
   ipc.on('toggleFullScreen', (e, ...args) => main.toggleFullScreen(...args))
+  ipc.on('setAllowNav', (e, ...args) => menu.setAllowNav(...args))
 
   /**
    * VLC

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -1,11 +1,10 @@
 module.exports = {
   init,
-  onPlayerClose,
-  onPlayerOpen,
+  setPlayerOpen,
+  setWindowFocus,
+  setAllowNav,
   onToggleAlwaysOnTop,
-  onToggleFullScreen,
-  onWindowBlur,
-  onWindowFocus
+  onToggleFullScreen
 }
 
 var electron = require('electron')
@@ -24,26 +23,28 @@ function init () {
   electron.Menu.setApplicationMenu(menu)
 }
 
-function onPlayerClose () {
-  getMenuItem('Play/Pause').enabled = false
-  getMenuItem('Increase Volume').enabled = false
-  getMenuItem('Decrease Volume').enabled = false
-  getMenuItem('Step Forward').enabled = false
-  getMenuItem('Step Backward').enabled = false
-  getMenuItem('Increase Speed').enabled = false
-  getMenuItem('Decrease Speed').enabled = false
-  getMenuItem('Add Subtitles File...').enabled = false
+function setPlayerOpen (flag) {
+  getMenuItem('Play/Pause').enabled = flag
+  getMenuItem('Increase Volume').enabled = flag
+  getMenuItem('Decrease Volume').enabled = flag
+  getMenuItem('Step Forward').enabled = flag
+  getMenuItem('Step Backward').enabled = flag
+  getMenuItem('Increase Speed').enabled = flag
+  getMenuItem('Decrease Speed').enabled = flag
+  getMenuItem('Add Subtitles File...').enabled = flag
 }
 
-function onPlayerOpen () {
-  getMenuItem('Play/Pause').enabled = true
-  getMenuItem('Increase Volume').enabled = true
-  getMenuItem('Decrease Volume').enabled = true
-  getMenuItem('Step Forward').enabled = true
-  getMenuItem('Step Backward').enabled = true
-  getMenuItem('Increase Speed').enabled = true
-  getMenuItem('Decrease Speed').enabled = true
-  getMenuItem('Add Subtitles File...').enabled = true
+function setWindowFocus (flag) {
+  getMenuItem('Full Screen').enabled = flag
+  getMenuItem('Float on Top').enabled = flag
+}
+
+// Disallow opening more screens on top of the current one.
+function setAllowNav (flag) {
+  getMenuItem('Preferences').enabled = flag
+  getMenuItem('Create New Torrent...').enabled = flag
+  var item = getMenuItem('Create New Torrent from File...')
+  if (item) item.enabled = flag
 }
 
 function onToggleAlwaysOnTop (flag) {
@@ -52,16 +53,6 @@ function onToggleAlwaysOnTop (flag) {
 
 function onToggleFullScreen (flag) {
   getMenuItem('Full Screen').checked = flag
-}
-
-function onWindowBlur () {
-  getMenuItem('Full Screen').enabled = false
-  getMenuItem('Float on Top').enabled = false
-}
-
-function onWindowFocus () {
-  getMenuItem('Full Screen').enabled = true
-  getMenuItem('Float on Top').enabled = true
 }
 
 function getMenuItem (label) {
@@ -130,14 +121,6 @@ function getMenuTemplate () {
         },
         {
           role: 'selectall'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Preferences',
-          accelerator: 'CmdOrCtrl+,',
-          click: () => windows.main.dispatch('preferences')
         }
       ]
     },
@@ -349,6 +332,17 @@ function getMenuTemplate () {
       label: 'Create New Torrent from File...',
       click: () => dialog.openSeedFile()
     })
+
+    // Edit menu (Windows, Linux)
+    template[1].submenu.push(
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Preferences',
+        accelerator: 'CmdOrCtrl+,',
+        click: () => windows.main.dispatch('preferences')
+      })
 
     // Help menu (Windows, Linux)
     template[4].submenu.push(

--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -1,8 +1,7 @@
 module.exports = {
   hasTray,
   init,
-  onWindowBlur,
-  onWindowFocus
+  setWindowFocus
 }
 
 var electron = require('electron')
@@ -31,12 +30,7 @@ function hasTray () {
   return !!tray
 }
 
-function onWindowBlur () {
-  if (!tray) return
-  updateTrayMenu()
-}
-
-function onWindowFocus () {
+function setWindowFocus (flag) {
   if (!tray) return
   updateTrayMenu()
 }

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -206,13 +206,13 @@ function toggleFullScreen (flag) {
 }
 
 function onWindowBlur () {
-  menu.onWindowBlur()
-  tray.onWindowBlur()
+  menu.setWindowFocus(false)
+  tray.setWindowFocus(false)
 }
 
 function onWindowFocus () {
-  menu.onWindowFocus()
-  tray.onWindowFocus()
+  menu.setWindowFocus(true)
+  tray.setWindowFocus(true)
 }
 
 function getIconPath () {

--- a/src/renderer/controllers/prefs-controller.js
+++ b/src/renderer/controllers/prefs-controller.js
@@ -1,4 +1,3 @@
-const {dispatch} = require('../lib/dispatcher')
 const State = require('../lib/state')
 const ipcRenderer = require('electron').ipcRenderer
 
@@ -16,11 +15,15 @@ module.exports = class PrefsController {
       url: 'preferences',
       setup: function (cb) {
         // initialize preferences
-        dispatch('setTitle', 'Preferences')
+        state.window.title = 'Preferences'
         state.unsaved = Object.assign(state.unsaved || {}, {prefs: state.saved.prefs || {}})
+        ipcRenderer.send('setAllowNav', false)
         cb()
       },
-      destroy: () => this.save()
+      destroy: () => {
+        ipcRenderer.send('setAllowNav', true)
+        this.save()
+      }
     })
   }
 

--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -40,6 +40,11 @@ module.exports = class TorrentListController {
 
   // Shows the Create Torrent page with options to seed a given file or folder
   showCreateTorrent (files) {
+    // You can only create torrents from the home screen.
+    if (this.state.location.url() !== 'home') {
+      return dispatch('error', 'Please go back to the torrent list before creating a new torrent.')
+    }
+
     // Files will either be an array of file objects, which we can send directly
     // to the create-torrent screen
     if (files.length === 0 || typeof files[0] !== 'string') {
@@ -67,9 +72,7 @@ module.exports = class TorrentListController {
     var state = this.state
     var torrentKey = state.nextTorrentKey++
     ipcRenderer.send('wt-create-torrent', torrentKey, options)
-    state.location.backToFirst(function () {
-      state.location.clearForward('create-torrent')
-    })
+    state.location.cancel()
   }
 
   // Starts downloading and/or seeding a given torrentSummary.

--- a/src/renderer/views/create-torrent-error-page.js
+++ b/src/renderer/views/create-torrent-error-page.js
@@ -16,7 +16,7 @@ module.exports = class CreateTorrentErrorPage extends React.Component {
           </p>
         </p>
         <p className='float-right'>
-          <button className='button-flat light' onClick={dispatcher('back')}>
+          <button className='button-flat light' onClick={dispatcher('cancel')}>
             Cancel
           </button>
         </p>

--- a/src/renderer/views/create-torrent.js
+++ b/src/renderer/views/create-torrent.js
@@ -89,7 +89,7 @@ module.exports = class CreateTorrentPage extends React.Component {
           </div>
         </div>
         <div key='buttons' className='float-right'>
-          <button key='cancel' className='button-flat light' onClick={dispatcher('back')}>Cancel</button>
+          <button key='cancel' className='button-flat light' onClick={dispatcher('cancel')}>Cancel</button>
           <button key='create' className='button-raised' onClick={handleOK}>Create Torrent</button>
         </div>
       </div>

--- a/src/renderer/views/preferences.js
+++ b/src/renderer/views/preferences.js
@@ -40,7 +40,7 @@ function renderDownloadDirSelector (state) {
   },
   state.unsaved.prefs.downloadPath,
   function (filePath) {
-    setStateValue('downloadPath', filePath)
+    dispatch('updatePreferences', 'downloadPath', filePath)
   })
 }
 
@@ -98,12 +98,18 @@ function renderSection (definition, controls) {
 // - callback takes a new file or folder path
 function renderFileSelector (definition, value, callback) {
   var controls = [(
-    <input type='text' className='file-picker-text'
+    <input
+      type='text'
+      className='file-picker-text'
+      key={definition.property}
       id={definition.property}
       disabled='disabled'
       value={value} />
   ), (
-    <button className='btn' onClick={handleClick}>
+    <button
+      key={definition.property + '-btn'}
+      className='btn'
+      onClick={handleClick}>
       <i className='icon'>folder_open</i>
     </button>
   )]
@@ -131,8 +137,4 @@ function renderControlGroup (definition, controls) {
       </div>
     </div>
   )
-}
-
-function setStateValue (property, value) {
-  dispatch('updatePreferences', property, value)
 }

--- a/src/renderer/views/torrent-list.js
+++ b/src/renderer/views/torrent-list.js
@@ -44,6 +44,7 @@ module.exports = class TorrentList extends React.Component {
     if (torrentSummary.playStatus) classes.push(torrentSummary.playStatus)
     if (isSelected) classes.push('selected')
     if (!infoHash) classes.push('disabled')
+    if (torrentSummary.torrrentKey) console.error('Missing torrentKey', torrentSummary)
     return (
       <div
         key={torrentSummary.torrentKey}

--- a/src/renderer/views/update-available-modal.js
+++ b/src/renderer/views/update-available-modal.js
@@ -11,18 +11,18 @@ module.exports = class UpdateAvailableModal extends React.Component {
         <p><strong>A new version of WebTorrent is available: v{state.modal.version}</strong></p>
         <p>We have an auto-updater for Windows and Mac. We don't have one for Linux yet, so you'll have to download the new version manually.</p>
         <p className='float-right'>
-          <button className='button button-flat' onClick={handleCancel}>Skip This Release</button>
-          <button className='button button-raised' onClick={handleOK}>Show Download Page</button>
+          <button className='button button-flat' onClick={handleSkip}>Skip This Release</button>
+          <button className='button button-raised' onClick={handleShow}>Show Download Page</button>
         </p>
       </div>
     )
 
-    function handleOK () {
+    function handleShow () {
       electron.shell.openExternal('https://github.com/feross/webtorrent-desktop/releases')
       dispatch('exitModal')
     }
 
-    function handleCancel () {
+    function handleSkip () {
       dispatch('skipVersion', state.modal.version)
       dispatch('exitModal')
     }


### PR DESCRIPTION
You can no longer open a whole stack of Prefs windows, or Create Torrent windows

Simplifies and fixes behavior when dropping files onto the app or the dock icon. Before, you could use drag-drop to create stacks of Create Torrent windows. Now, you can only create torrents from the home screen.

Fixes #665