### PR TITLE
Update Electron to 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deep-equal": "^1.0.1",
     "dlnacasts": "^0.1.0",
     "drag-drop": "^2.12.1",
-    "electron-prebuilt": "1.3.2",
+    "electron-prebuilt": "1.3.3",
     "fs-extra": "^0.30.0",
     "hat": "0.0.3",
     "iso-639-1": "^1.2.1",

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -141,7 +141,9 @@ function setBounds (bounds, maximize) {
       bounds.y = Math.round(scr.bounds.y + scr.bounds.height / 2 - bounds.height / 2)
       log('setBounds: centered to ' + JSON.stringify(bounds))
     }
-    main.win.setBounds(bounds, true)
+    // Resize the window's content area (so window border doesn't need to be taken
+    // into account)
+    main.win.setContentBounds(bounds, true)
   } else {
     log('setBounds: not setting bounds because of window maximization')
   }


### PR DESCRIPTION
Fixes: https://github.com/feross/webtorrent-desktop/issues/565

This was trivial thanks to a new Electron API in 1.3.3, browserWindow.setContentBounds()