### PR TITLE
If a power saver block already exists, do nothing

### DIFF
--- a/src/main/power-save-blocker.js
+++ b/src/main/power-save-blocker.js
@@ -13,7 +13,10 @@ var blockId = 0
  * display.
  */
 function enable () {
-  disable() // Stop the previous power saver block, if one exists.
+  if (electron.powerSaveBlocker.isStarted(blockId)) {
+    // If a power saver block already exists, do nothing.
+    return
+  }
   blockId = electron.powerSaveBlocker.start('prevent-display-sleep')
   log(`powerSaveBlocker.enable: ${blockId}`)
 }
@@ -23,6 +26,7 @@ function enable () {
  */
 function disable () {
   if (!electron.powerSaveBlocker.isStarted(blockId)) {
+    // If a power saver block does not exist, do nothing.
     return
   }
   electron.powerSaveBlocker.stop(blockId)


### PR DESCRIPTION
Before this change, when opening the player, both 'onPlayerOpen' and
'onPlayerPlay' would fire, which enabled, disabled, and re-enabled the
power save blocker in quick succession.

Instead, we just want to activate it once.