### PR TITLE
Telemtry: post at least once a day

### DIFF
--- a/src/renderer/lib/telemetry.js
+++ b/src/renderer/lib/telemetry.js
@@ -32,6 +32,8 @@ function init (state) {
 
   if (config.IS_PRODUCTION) {
     postToServer()
+    // If the user keeps WebTorrent running for a long time, post every 24h
+    setInterval(postToServer, 24 * 3600 * 1000)
   } else {
     // Development: telemetry used only for local debugging
     // Empty uncaught errors, etc at the start of every run


### PR DESCRIPTION
This ensures that people who keep the app running in the background
for days at a time are still counted as active users.