### PR TITLE
Bugfixes

### DIFF
--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -93,6 +93,10 @@ module.exports = class PlaybackController {
 
   // Skip (aka seek) to a specific point, in seconds
   skipTo (time) {
+    if (!Number.isFinite(time)) {
+      console.error('Tried to skip to a non-finite time ' + time)
+      return console.trace()
+    }
     if (isCasting(this.state)) Cast.seek(time)
     else this.state.playing.jumpToTime = time
   }

--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -263,7 +263,7 @@ function deleteFile (path) {
 // Delete all files in a torrent
 function moveItemToTrash (torrentSummary) {
   var filePath = TorrentSummary.getFileOrFolder(torrentSummary)
-  ipcRenderer.send('moveItemToTrash', filePath)
+  if (filePath) ipcRenderer.send('moveItemToTrash', filePath)
 }
 
 function showItemInFolder (torrentSummary) {

--- a/src/renderer/lib/cast.js
+++ b/src/renderer/lib/cast.js
@@ -396,7 +396,9 @@ function stop () {
 
 function stoppedCasting () {
   state.playing.location = 'local'
-  state.playing.jumpToTime = state.playing.currentTime
+  state.playing.jumpToTime = Number.isFinite(state.playing.currentTime)
+    ? state.playing.currentTime
+    : 0
   update()
 }
 

--- a/src/renderer/lib/torrent-summary.js
+++ b/src/renderer/lib/torrent-summary.js
@@ -52,5 +52,6 @@ function getByKey (state, torrentKey) {
 // module. Store root folder explicitly to avoid hacky path processing below.
 function getFileOrFolder (torrentSummary) {
   var ts = torrentSummary
+  if (!ts.path || !ts.files || ts.files.length === 0) return null
   return path.join(ts.path, ts.files[0].path.split('/')[0])
 }


### PR DESCRIPTION
Here's our current list of top 10 bugs from https://webtorrent.io/desktop/telemetry/:

|Count|Example message|Status|
|------|------------------|------|
|2104|[object Object]|No idea, no stacktrace|
|632|[object HTMLVideoElement]|No idea, no stacktrace|
|359|Cannot read property 'getHostNode' of null|Happens after a React component throws an error in render(). Will go away by itself once we fix those errors, logged separately.|
|284|Failed to set the 'currentTime' property on 'HTMLMediaElement': The provided double value is non-finite.|**Fixed in this PR**|
|78|Cannot read property '0' of undefined|**Fixed in this PR**|
|62|Illegal wire type for field Message.Field...|Filed: https://github.com/thibauts/node-castv2/issues/35|
|59|torrent is destroyed|Bug in webtorrent.js, already filed|
|51|You can't connect to dlna when already connected to another device|Np. Comes from our own UI; should just use addError instead of throwing an uncaught exception.|
|48|val is not defined|Filed: https://github.com/thibauts/node-castv2/issues/36|
|47|Cannot read property 'message' of undefined|Bug in older version of WebTorrent, can't happen in the current telemetry.js|
