### PR TITLE
Fix playback + download of default torrents

### DIFF
--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -84,21 +84,30 @@ module.exports = class TorrentListController {
     var s = TorrentSummary.getByKey(this.state, torrentKey)
     if (!s) throw new Error('Missing key: ' + torrentKey)
 
-    // Use Downloads folder by default
-    if (!s.path) s.path = this.state.saved.prefs.downloadPath
+    // New torrent: give it a path
+    if (!s.path) {
+      // Use Downloads folder by default
+      s.path = this.state.saved.prefs.downloadPath
+      return start()
+    }
 
+    // Existing torrent: check that the path is still there
     fs.stat(TorrentSummary.getFileOrFolder(s), function (err) {
       if (err) {
         s.error = 'path-missing'
         return
       }
+      start()
+    })
+
+    function start () {
       ipcRenderer.send('wt-start-torrenting',
         s.torrentKey,
         TorrentSummary.getTorrentID(s),
         s.path,
         s.fileModtimes,
         s.selections)
-    })
+    }
   }
 
   // TODO: use torrentKey, not infoHash


### PR DESCRIPTION
There was a terrible bug introduced in https://github.com/feross/webtorrent-desktop/commit/0809e20a6e1de917a2f8315c2f1da3b9ef177a43 -- clicking play on any of the default torrents in a fresh install of the app would fail and result in a 'path missing' error.

This fixes the bug, and also adds a migration step to clean up resulting broken config files