### PR TITLE
Don't open partially downloaded files in external app

### DIFF
--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -38,7 +38,7 @@ module.exports = class PlaybackController {
     })
   }
 
-  // Show a file in the OS, eg in Finder on a Mac
+  // Open a file in OS default app.
   openItem (infoHash, index) {
     var torrentSummary = TorrentSummary.getByKey(this.state, infoHash)
     var filePath = path.join(

--- a/src/renderer/pages/TorrentListPage.js
+++ b/src/renderer/pages/TorrentListPage.js
@@ -322,8 +322,11 @@ module.exports = class TorrentList extends React.Component {
       handleClick = dispatcher('playFile', infoHash, index)
     } else {
       icon = 'description' /* file icon, opens in OS default app */
-      handleClick = dispatcher('openItem', infoHash, index)
+      handleClick = isDone
+        ? dispatcher('openItem', infoHash, index)
+        : (e) => e.stopPropagation() // noop if file is not ready
     }
+    // TODO: add a css 'disabled' class to indicate that a file cannot be opened/streamed
     var rowClass = ''
     if (!isSelected) rowClass = 'disabled' // File deselected, not being torrented
     if (!isDone && !isPlayable) rowClass = 'disabled' // Can't open yet, can't stream


### PR DESCRIPTION
Fixes #810 

It might be cleaner to handle this directly in the PlaybackController`openItem` method, or to create a noop dispatcher function?