### PR TITLE
remember window position

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ console.log('Production: %s portable: %s test: %s',
   IS_PRODUCTION, IS_PORTABLE, IS_TEST)
 if (IS_PORTABLE) console.log('Portable path: %s', PORTABLE_PATH)
 
-module.exports = {
+let cfg = {
   ANNOUNCEMENT_URL: 'https://webtorrent.io/desktop/announcement',
   AUTO_UPDATE_URL: 'https://webtorrent.io/desktop/update',
   CRASH_REPORT_URL: 'https://webtorrent.io/desktop/crash-report',
@@ -93,8 +93,18 @@ module.exports = {
   WINDOW_WEBTORRENT: 'file://' + path.join(__dirname, '..', 'static', 'webtorrent.html'),
 
   WINDOW_MIN_HEIGHT: 38 + (120 * 2), // header height + 2 torrents
-  WINDOW_MIN_WIDTH: 425
+  WINDOW_MIN_WIDTH: 425,
+
+  UI_HEADER_HEIGHT: 38,
+  UI_TORRENT_HEIGHT: 100
 }
+
+cfg.DEFAULT_BOUNDS = {
+  width: 500,
+  height: cfg.UI_HEADER_HEIGHT + (cfg.UI_TORRENT_HEIGHT * (cfg.DEFAULT_TORRENTS.length + 1))
+}
+
+module.exports = cfg
 
 function getConfigPath () {
   if (IS_PORTABLE) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -13,6 +13,7 @@ const ipc = require('./ipc')
 const log = require('./log')
 const menu = require('./menu')
 const squirrelWin32 = require('./squirrel-win32')
+const State = require('../renderer/lib/state')
 const tray = require('./tray')
 const updater = require('./updater')
 const userTasks = require('./user-tasks')
@@ -72,7 +73,10 @@ function init () {
   app.on('ready', function () {
     isReady = true
 
-    windows.main.init({hidden: hidden})
+    State.load(function (err, state) {
+      if (err) throw err
+      windows.main.init(state, {hidden: hidden})
+    })
     windows.webtorrent.init()
     menu.init()
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -288,6 +288,7 @@ function setupIpc () {
   ipcRenderer.on('dispatch', (e, ...args) => dispatch(...args))
 
   ipcRenderer.on('fullscreenChanged', onFullscreenChanged)
+  ipcRenderer.on('windowBoundsChanged', onWindowBoundsChanged)
 
   const tc = controllers.torrent
   ipcRenderer.on('wt-infohash', (e, ...args) => tc.torrentInfoHash(...args))
@@ -460,6 +461,11 @@ function onFullscreenChanged (e, isFullScreen) {
   }
 
   update()
+}
+
+function onWindowBoundsChanged (e, newBounds) {
+  state.saved.bounds = newBounds
+  dispatch('saveStateThrottled')
 }
 
 function checkDownloadPath () {


### PR DESCRIPTION
Closes #181

- Save the bounds of the window when its resized or moved.
- Stored in config.json under "bounds" key (state.saved.bounds)

One oddity: the window is shown at its default centered position until the renderer starts and the state gets loaded, then the window is moved to its saved bounds. 

Setting the bounds when the window is created is possible, but it means loading the state way earlier... (and possibly loading it again once the renderer starts). Any thoughts on acceptable ways to solve this/mitigate the jank at startup?

