### PR TITLE
fix: add missing console.timeEnd

### DIFF
--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -97,6 +97,7 @@ function init () {
     true)
 
   setInterval(updateTorrentProgress, 1000)
+  console.timeEnd('init')
 }
 
 // Starts a given TorrentID, which can be an infohash, magnet URI, etc. Returns WebTorrent object


### PR DESCRIPTION
Noticed the webtorrent renderer instance has a `console.time('init')` with a missing `console.timeEnd('init')` counterpart. Thought I'd add it in at the end of the `init()` function.