### PR TITLE
Fix npm run package

### DIFF
--- a/src/renderer/pages/App.js
+++ b/src/renderer/pages/App.js
@@ -5,7 +5,7 @@ const darkBaseTheme = require('material-ui/styles/baseThemes/darkBaseTheme').def
 const getMuiTheme = require('material-ui/styles/getMuiTheme').default
 const MuiThemeProvider = require('material-ui/styles/MuiThemeProvider').default
 
-const Header = require('../components/Header')
+const Header = require('../components/header')
 
 const Views = {
   'home': require('./TorrentListPage'),


### PR DESCRIPTION
A require() had the wrong case, which apparently works for `npm start` build but fails in the packaged app

@noamokman @mathiasvr 