### PR TITLE
Fix Create Torrent file list

### DIFF
--- a/src/renderer/pages/CreateTorrentPage.js
+++ b/src/renderer/pages/CreateTorrentPage.js
@@ -140,7 +140,7 @@ class CreateTorrentPage extends React.Component {
       return (<div key={i}>{relativePath}</div>)
     })
     if (files.length > maxFileElems) {
-      fileElems.push(<div key='more'>+ {maxFileElems - files.length} more</div>)
+      fileElems.push(<div key='more'>+ {files.length - maxFileElems} more</div>)
     }
 
     // Align the text fields


### PR DESCRIPTION
Trivial bug. When there are too many files in the Create Torrent screen, we currently say "+ -80 more" instead of "+ 80 more"