### PR TITLE
Fix error on Windows caused by `setBadge`

### DIFF
--- a/src/main/dock.js
+++ b/src/main/dock.js
@@ -4,9 +4,7 @@ module.exports = {
   setBadge
 }
 
-var electron = require('electron')
-
-var app = electron.app
+var {app, Menu} = require('electron')
 
 var dialog = require('./dialog')
 var log = require('./log')
@@ -16,7 +14,7 @@ var log = require('./log')
  */
 function init () {
   if (!app.dock) return
-  var menu = electron.Menu.buildFromTemplate(getMenuTemplate())
+  var menu = Menu.buildFromTemplate(getMenuTemplate())
   app.dock.setMenu(menu)
 }
 
@@ -33,8 +31,11 @@ function downloadFinished (path) {
  * Display a counter badge for the app. (Mac, Linux)
  */
 function setBadge (count) {
-  log(`setBadge: ${count}`)
-  app.setBadgeCount(Number(count))
+  if (process.platform === 'darwin' ||
+      process.platform === 'linux' && app.isUnityRunning()) {
+    log(`setBadge: ${count}`)
+    app.setBadgeCount(Number(count))
+  }
 }
 
 function getMenuTemplate () {


### PR DESCRIPTION
On each startup with `npm start` on Windows, the following error appears in the terminal:

```
TypeError: app.setBadgeCount is not a function
    at Object.setBadge (C:\Users\Goldob\Projekty\NodeJS\webtorrent-desktop\build\main\dock.js:37:7)
    at EventEmitter.ipc.on (C:\Users\Goldob\Projekty\NodeJS\webtorrent-desktop\build\main\ipc.js:52:43)
    at emitTwo (events.js:106:13)
    at EventEmitter.emit (events.js:191:7)
    at EventEmitter.ipc.emit (C:\Users\Goldob\Projekty\NodeJS\webtorrent-desktop\build\main\ipc.js:150:13)
    at EventEmitter.<anonymous> (C:\Users\Goldob\Projekty\NodeJS\webtorrent-desktop\node_modules\electron-prebuilt\dist\resources\electron.asar\browser\api\web-contents.js:156:13)
    at emitTwo (events.js:106:13)
    at EventEmitter.emit (events.js:191:7)
```

This PR fixes that by ensuring that we are running either Mac or Linux with Unity before calling the API.