### PR TITLE
Ensure that torrent file metadata is present

### DIFF
--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -84,8 +84,13 @@ module.exports = class TorrentListController {
       return start()
     }
 
+    var fileOrFolder = TorrentSummary.getFileOrFolder(s)
+
+    // New torrent: metadata not yet received
+    if (!fileOrFolder) return start()
+
     // Existing torrent: check that the path is still there
-    fs.stat(TorrentSummary.getFileOrFolder(s), function (err) {
+    fs.stat(fileOrFolder, function (err) {
       if (err) {
         s.error = 'path-missing'
         return


### PR DESCRIPTION
Fixes #854

When starting WebTorrent 'new' torrents usually don't have any `.files` yet, causing an error when calling fs.stat with a null parameter.