### PR TITLE
Early telemetry

### DIFF
--- a/src/renderer/lib/telemetry.js
+++ b/src/renderer/lib/telemetry.js
@@ -128,10 +128,6 @@ function logUncaughtError (procName, e) {
   var stack = ''
   if (e == null) {
     message = 'Unexpected undefined error'
-  } else if (e.message) {
-    // err is either an Error or a plain object {message, stack}
-    message = e.message
-    stack = e.stack
   } else if (e.error) {
     // Uncaught Javascript errors (window.onerror), err is an ErrorEvent
     if (!e.error.message) {
@@ -140,6 +136,10 @@ function logUncaughtError (procName, e) {
       message = e.error.message
       stack = e.error.stack
     }
+  } else if (e.message) {
+    // err is either an Error or a plain object {message, stack}
+    message = e.message
+    stack = e.stack
   } else {
     // Resource errors (captured element.onerror), err is an Event
     if (!e.target) {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -59,6 +59,13 @@ function onState (err, _state) {
   if (err) return onError(err)
   state = window.state = _state // Make available for easier debugging
 
+  telemetry.init(state)
+
+  // Log uncaught JS errors
+  window.addEventListener('error',
+    (e) => telemetry.logUncaughtError('window', e),
+    true /* capture */)
+
   // Create controllers
   controllers = {
     media: new MediaController(state),
@@ -114,11 +121,6 @@ function onState (err, _state) {
   // ...window visibility state.
   document.addEventListener('webkitvisibilitychange', onVisibilityChange)
 
-  // Log uncaught JS errors
-  window.addEventListener('error',
-    (e) => telemetry.logUncaughtError('window', e),
-    true /* capture */)
-
   // Done! Ideally we want to get here < 500ms after the user clicks the app
   sound.play('STARTUP')
   console.timeEnd('init')
@@ -128,7 +130,6 @@ function onState (err, _state) {
 function delayedInit () {
   lazyLoadCast()
   sound.preload()
-  telemetry.init(state)
 }
 
 // Lazily loads Chromecast and Airplay support


### PR DESCRIPTION
To follow up on #854.

Telemetry was not initialized early enough to catch this error. I moved it from `delayedInit` and didn't experience a noticeable change in startup time.

Another problem was that the stack trace was `undefined` because `e` was used instead of `e.error`, so I swapped the if statements.

Also it might be a good idea to `console.log` the uncaught errors, instead of only logging them for telemetry?

@dcposch 