### PR TITLE
Telemetry: fix stacktrace redaction

### DIFF
--- a/src/renderer/lib/telemetry.js
+++ b/src/renderer/lib/telemetry.js
@@ -158,6 +158,7 @@ function logUncaughtError (procName, e) {
   // - Privacy: remove personal info like C:\Users\<full name>
   // - Aggregation: this lets us find which stacktraces occur often
   stack = stack.replace(/\(.*app.asar/g, '(...')
+  stack = stack.replace(/at .*app.asar/g, 'at ...')
 
   // We need to POST the telemetry object, make sure it stays < 100kb
   if (telemetry.uncaughtErrors.length > 20) return


### PR DESCRIPTION
The following stacktrace slipped past our redaction:

```
Processes: webtorrent, platforms: win32, versions: 0.13.1 
RangeError: Array buffer allocation failed
    at Buffer.Uint8Array (native)
    at FastBuffer (buffer.js:8:1)
    at createUnsafeBuffer (buffer.js:33:12)
    at allocate (buffer.js:176:12)
    at Function.Buffer.allocUnsafe (buffer.js:136:10)
    at Function.Buffer.concat (buffer.js:326:23)
    at C:\Users\Matt\AppData\Local\WebTorrent\app-0.13.1\resources\app.asar\node_modules\fs-chunk-store\index.js:200:23
    at end (...\node_modules\run-parallel\index.js:16:15)
    at done (...\node_modules\run-parallel\index.js:20:10)
    at each (...\node_modules\run-parallel\index.js:26:7)
```

...notice how all lines except that middle one are redacted with a (...).

So yeah, we have at least one user named Matt :)

This makes stacktrace redaction more thorough.