### PR TITLE
Restore playback state when reopening player

### DIFF
--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -34,12 +34,20 @@ module.exports = class PlaybackController {
         else this.play()
       })
     } else {
+      let initialized = false
       state.location.go({
         url: 'player',
         setup: (cb) => {
-          this.play()
+          const torrentSummary = TorrentSummary.getByKey(state, infoHash)
+
+          if (index === undefined || initialized) index = torrentSummary.mostRecentFileIndex
+          if (index === undefined) index = torrentSummary.files.findIndex(TorrentPlayer.isPlayable)
+          if (index === undefined) return cb(new errors.UnplayableError())
+
+          initialized = true
+
           this.openPlayer(infoHash, index, (err) => {
-            if (!err) this.play
+            if (!err) this.play()
             cb(err)
           })
         },
@@ -210,10 +218,6 @@ module.exports = class PlaybackController {
   openPlayer (infoHash, index, cb) {
     const state = this.state
     const torrentSummary = TorrentSummary.getByKey(state, infoHash)
-
-    if (index === undefined) index = torrentSummary.mostRecentFileIndex
-    if (index === undefined) index = torrentSummary.files.findIndex(TorrentPlayer.isPlayable)
-    if (index === undefined) return cb(new errors.UnplayableError())
 
     state.playing.infoHash = torrentSummary.infoHash
 


### PR DESCRIPTION
This is a follow up for PR #871.

The intended behavior was that when opening player, playing some files and then navigating backward/forward in the app, the playback state is restored. In one particular case, when we open a specific file instead of a torrent and then do the above, the playback starts again at the same file it started at instead.

This PR fixes that.