### PR TITLE
make "npm run watch" work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "test": "standard && depcheck --ignores=babel-cli,nodemon,gh-release --ignore-dirs=build,dist && node ./bin/extra-lint.js",
     "gh-release": "gh-release",
     "update-authors": "./bin/update-authors.sh",
-    "watch": "nodemon --exec 'npm run start' --ext js,pug,css"
+    "watch": "nodemon --exec \"npm run start\" --ext js,pug,css"
   }
 }


### PR DESCRIPTION
Hi,
This technically fixes #861.
Originally written in #837, but separated to a different PR.

Thanks!

@dcposch @jurgentreep