### PR TITLE
Make git ignore npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 build/
 dist/
-npm-debug.log.*
+npm-debug.log*


### PR DESCRIPTION
Fix `.gitgnore` false negative for `npm-debug.log` file. Consistent with [GitHub's repo](https://github.com/github/gitignore/blob/master/Node.gitignore#L4).