### PR TITLE
Move error definitions to `errors.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dlnacasts": "^0.1.0",
     "drag-drop": "^2.12.1",
     "electron": "1.3.3",
+    "es6-error": "^3.0.1",
     "fs-extra": "^0.30.0",
     "iso-639-1": "^1.2.1",
     "languagedetect": "^1.1.1",

--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -4,7 +4,10 @@ const path = require('path')
 const Cast = require('../lib/cast')
 const {dispatch} = require('../lib/dispatcher')
 const telemetry = require('../lib/telemetry')
-const errors = require('../lib/errors')
+const {
+      UnplayableFileError,
+      UnplayableTorrentError,
+      PlaybackTimedOutError } = require('../lib/errors')
 const sound = require('../lib/sound')
 const TorrentPlayer = require('../lib/torrent-player')
 const TorrentSummary = require('../lib/torrent-summary')
@@ -42,7 +45,7 @@ module.exports = class PlaybackController {
 
           if (index === undefined || initialized) index = torrentSummary.mostRecentFileIndex
           if (index === undefined) index = torrentSummary.files.findIndex(TorrentPlayer.isPlayable)
-          if (index === undefined) return cb(new errors.UnplayableError())
+          if (index === undefined) return cb(new UnplayableTorrentError())
 
           initialized = true
 
@@ -232,7 +235,7 @@ module.exports = class PlaybackController {
       // TODO: remove torrentSummary.playStatus
       torrentSummary.playStatus = 'timeout' /* no seeders available? */
       sound.play('ERROR')
-      cb(new Error('Playback timed out. Try again.'))
+      cb(new PlaybackTimedOutError())
       this.update()
     }, 10000) /* give it a few seconds */
 
@@ -277,7 +280,7 @@ module.exports = class PlaybackController {
 
     if (!TorrentPlayer.isPlayable(fileSummary)) {
       torrentSummary.mostRecentFileIndex = undefined
-      return cb(new Error('Can\'t play that file'))
+      return cb(new UnplayableFileError())
     }
 
     torrentSummary.mostRecentFileIndex = index

--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -4,10 +4,8 @@ const path = require('path')
 const Cast = require('../lib/cast')
 const {dispatch} = require('../lib/dispatcher')
 const telemetry = require('../lib/telemetry')
-const {
-      UnplayableFileError,
-      UnplayableTorrentError,
-      PlaybackTimedOutError } = require('../lib/errors')
+const {UnplayableFileError, UnplayableTorrentError,
+      PlaybackTimedOutError} = require('../lib/errors')
 const sound = require('../lib/sound')
 const TorrentPlayer = require('../lib/torrent-player')
 const TorrentSummary = require('../lib/torrent-summary')

--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -3,6 +3,7 @@ const path = require('path')
 const electron = require('electron')
 
 const {dispatch} = require('../lib/dispatcher')
+const {TorrentKeyNotFoundError} = require('../lib/errors')
 const State = require('../lib/state')
 const sound = require('../lib/sound')
 const TorrentSummary = require('../lib/torrent-summary')
@@ -75,7 +76,7 @@ module.exports = class TorrentListController {
   // Starts downloading and/or seeding a given torrentSummary.
   startTorrentingSummary (torrentKey) {
     const s = TorrentSummary.getByKey(this.state, torrentKey)
-    if (!s) throw new Error('Missing key: ' + torrentKey)
+    if (!s) throw new TorrentKeyNotFoundError(torrentKey)
 
     // New torrent: give it a path
     if (!s.path) {

--- a/src/renderer/lib/capture-video-frame.js
+++ b/src/renderer/lib/capture-video-frame.js
@@ -1,12 +1,14 @@
 module.exports = captureVideoFrame
 
+const {IllegalArgumentError} = require('./errors')
+
 function captureVideoFrame (video, format) {
   if (typeof video === 'string') {
     video = document.querySelector(video)
   }
 
   if (video == null || video.nodeName !== 'VIDEO') {
-    throw new Error('First argument must be a <video> element or selector')
+    throw new IllegalArgumentError('First argument must be a <video> element or selector')
   }
 
   if (format == null) {
@@ -14,7 +16,7 @@ function captureVideoFrame (video, format) {
   }
 
   if (format !== 'png' && format !== 'jpg' && format !== 'webp') {
-    throw new Error('Second argument must be one of "png", "jpg", or "webp"')
+    throw new IllegalArgumentError('Second argument must be one of "png", "jpg", or "webp"')
   }
 
   const canvas = document.createElement('canvas')

--- a/src/renderer/lib/cast.js
+++ b/src/renderer/lib/cast.js
@@ -14,6 +14,7 @@ module.exports = {
 }
 
 const config = require('../../config')
+const {CastingError} = require('./errors')
 
 // Lazy load these for a ~300ms improvement in startup time
 let airplayer, chromecasts, dlnacasts
@@ -350,14 +351,16 @@ function toggleMenu (location) {
 
   // Never cast to two devices at the same time
   if (state.playing.location !== 'local') {
-    throw new Error('You can\'t connect to ' + location +
-      ' when already connected to another device')
-  }
+    throw new CastingError(
+      `You can't connect to ${location} when already connected to another device`
+    ) }
 
   // Find all cast devices of the given type
   const player = getPlayer(location)
   const devices = player ? player.getDevices() : []
-  if (devices.length === 0) throw new Error('No ' + location + ' devices available')
+  if (devices.length === 0) {
+    throw new CastingError(`No ${location} devices available`)
+  }
 
   // Show a menu
   state.devices.castMenu = {location, devices}

--- a/src/renderer/lib/errors.js
+++ b/src/renderer/lib/errors.js
@@ -1,15 +1,54 @@
+const ExtendableError = require('es6-error')
+
+/* Generic errors */
+
+class CastingError extends ExtendableError {}
+class PlaybackError extends ExtendableError {}
+class SoundError extends ExtendableError {}
+class TorrentError extends ExtendableError {}
+
+/* Playback */
+
+class UnplayableTorrentError extends PlaybackError {
+  constructor () { super('Can\'t play any files in torrent') }
+}
+
+class UnplayableFileError extends PlaybackError {
+  constructor () { super('Can\'t play that file') }
+}
+
+class PlaybackTimedOutError extends PlaybackError {
+  constructor () { super('Playback timed out. Try again.') }
+}
+
+/* Sound */
+
+class InvalidSoundNameError extends SoundError {
+  constructor (name) { super(`Invalid sound name: ${name}`) }
+}
+
+/* Torrent */
+
+class TorrentKeyNotFoundError extends TorrentError {
+  constructor (torrentKey) { super(`Can't resolve torrent key ${torrentKey}`) }
+}
+
+class InvalidTorrentError extends TorrentError {}
+
+/* Miscellaneous */
+
+class IllegalArgumentError extends ExtendableError {}
+
 module.exports = {
+  CastingError,
+  PlaybackError,
+  SoundError,
+  TorrentError,
   UnplayableTorrentError,
-  UnplayableFileError
+  UnplayableFileError,
+  PlaybackTimedOutError,
+  InvalidSoundNameError,
+  TorrentKeyNotFoundError,
+  InvalidTorrentError,
+  IllegalArgumentError
 }
-
-function UnplayableTorrentError () {
-  this.message = 'Can\'t play any files in torrent'
-}
-
-function UnplayableFileError () {
-  this.message = 'Can\'t play that file'
-}
-
-UnplayableTorrentError.prototype = Error
-UnplayableFileError.prototype = Error

--- a/src/renderer/lib/sound.js
+++ b/src/renderer/lib/sound.js
@@ -4,6 +4,7 @@ module.exports = {
 }
 
 const config = require('../../config')
+const {InvalidSoundNameError} = require('./errors')
 const path = require('path')
 
 const VOLUME = 0.15
@@ -62,7 +63,7 @@ function play (name) {
   if (!audio) {
     const sound = sounds[name]
     if (!sound) {
-      throw new Error('Invalid sound name')
+      throw new InvalidSoundNameError(name)
     }
     audio = cache[name] = new window.Audio()
     audio.volume = sound.volume

--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -4,6 +4,7 @@ const prettyBytes = require('prettier-bytes')
 const TorrentSummary = require('../lib/torrent-summary')
 const TorrentPlayer = require('../lib/torrent-player')
 const {dispatcher} = require('../lib/dispatcher')
+const {InvalidTorrentError} = require('../lib/errors')
 
 module.exports = class TorrentList extends React.Component {
   render () {
@@ -58,7 +59,7 @@ module.exports = class TorrentList extends React.Component {
     if (torrentSummary.playStatus) classes.push(torrentSummary.playStatus)
     if (isSelected) classes.push('selected')
     if (!infoHash) classes.push('disabled')
-    if (!torrentSummary.torrentKey) throw new Error('Missing torrentKey')
+    if (!torrentSummary.torrentKey) throw new InvalidTorrentError('Missing torrentKey')
     return (
       <div
         key={torrentSummary.torrentKey}

--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -15,6 +15,7 @@ const zeroFill = require('zero-fill')
 
 const crashReporter = require('../crash-reporter')
 const config = require('../config')
+const {TorrentKeyNotFoundError} = require('./lib/errors')
 const torrentPoster = require('./lib/torrent-poster')
 
 // Report when the process crashes
@@ -384,7 +385,7 @@ function selectFiles (torrentOrInfoHash, selections) {
 // Throws an Error if we're not currently torrenting anything w/ that key
 function getTorrent (torrentKey) {
   const ret = client.torrents.find((x) => x.key === torrentKey)
-  if (!ret) throw new Error('missing torrent key ' + torrentKey)
+  if (!ret) throw new TorrentKeyNotFoundError(torrentKey)
   return ret
 }
 


### PR DESCRIPTION
* Moved most of the error definitions to dedicated `errors.js` file, which was hanging unused until now
* Created separate classes for different types of errors to increase verbosity and get rid of vague errors
* Fixed a typo in error name inside `playback-controller.js` possibly resulting in a `TypeError`