### PR TITLE
Fix Open Torrent Address modal

### DIFF
--- a/src/renderer/components/open-torrent-address-modal.js
+++ b/src/renderer/components/open-torrent-address-modal.js
@@ -11,6 +11,7 @@ module.exports = class OpenTorrentAddressModal extends React.Component {
         <p><label>Enter torrent address or magnet link</label></p>
         <div>
           <TextField
+            id='torrent-address-field'
             className='control'
             ref={(c) => { this.torrentURL = c }}
             fullWidth
@@ -31,7 +32,7 @@ module.exports = class OpenTorrentAddressModal extends React.Component {
 }
 
 function handleKeyDown (e) {
-  if (e.which === 13) this.handleOK() /* hit Enter to submit */
+  if (e.which === 13) handleOK.call(this) /* hit Enter to submit */
 }
 
 function handleOK () {


### PR DESCRIPTION
Fixes a bug introduced in 0.14.0: clicking OK works, but hitting Enter doesn't do anything.

Showed up as an uncaught error in telemetry:

```
Processes: window, platforms: linux win32, versions: 0.14.0
TypeError: this.handleOK is not a function
    at OpenTorrentAddressModal.handleKeyDown (...\build\renderer\components\open-torrent-address-modal.js:51:28)
    at TextField._this.handleInputKeyDown (...\node_modules\material-ui\TextField\TextField.js:205:46)
    at Object.invokeGuardedCallback (...\node_modules\react\lib\ReactErrorUtils.js:26:12)
    at executeDispatch (...\node_modules\react\lib\EventPluginUtils.js:89:21)
    at Object.executeDispatchesInOrder (...\node_modules\react\lib\EventPluginUtils.js:112:5)
    at executeDispatchesAndRelease (...\node_modules\react\lib\EventPluginHub.js:44:22)
    at executeDispatchesAndReleaseTopLevel (...\node_modules\react\lib\EventPluginHub.js:55:10)
    at Array.forEach (native)
    at forEachAccumulated (...\node_modules\react\lib\forEachAccumulated.js:25:9)
    at Object.processEventQueue (...\node_modules\react\lib\EventPluginHub.js:231:7)
```