### PR TITLE
Update mouse moved time on header hover

### DIFF
--- a/src/renderer/components/header.js
+++ b/src/renderer/components/header.js
@@ -6,7 +6,7 @@ class Header extends React.Component {
   render () {
     const loc = this.props.state.location
     return (
-      <div className='header'>
+      <div className='header' onMouseMove={dispatcher('mediaMouseMoved')}>
         {this.getTitle()}
         <div className='nav left float-left'>
           <i


### PR DESCRIPTION
Previously, moving the mouse into the player window from the sides or
bottom would bring up the HUD, but moving the mouse in from the top
would not. With this commit, moving the mouse in from the top of the
window will also bring up the HUD.

Fixes feross/webtorrent-desktop#241