### PR TITLE
Electron 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deep-equal": "^1.0.1",
     "dlnacasts": "^0.1.0",
     "drag-drop": "^2.12.1",
-    "electron": "1.3.5",
+    "electron": "1.4.0",
     "es6-error": "^3.0.1",
     "fs-extra": "^0.30.0",
     "iso-639-1": "^1.2.1",


### PR DESCRIPTION
The changes that are relevant to us are:

- Upgrade to Chrome 53.
- Upgrade to Node 6.5.0.
- Add support for titleBarStyle: 'hidden-inset' on OS X 10.9.

The last item should improve our UI on OS X 10.9 since we use 'hidden-inset'. I don't know what it looked like before.