### PR TITLE
Detect system architecture; send in update/telemetry

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -81,6 +81,8 @@ module.exports = {
   IS_PRODUCTION: IS_PRODUCTION,
   IS_TEST: IS_TEST,
 
+  OS_SYSARCH: is64BitOperatingSystem() ? 'x64' : 'ia32',
+
   POSTER_PATH: path.join(getConfigPath(), 'Posters'),
   ROOT_PATH: path.join(__dirname, '..'),
   STATIC_PATH: path.join(__dirname, '..', 'static'),
@@ -148,4 +150,33 @@ function isProduction () {
   if (process.platform === 'linux') {
     return !/\/electron$/.test(process.execPath)
   }
+}
+
+/**
+ * Returns the operating system's CPU architecture. This is different than
+ * `process.arch` which returns the architecture the binary was compiled for.
+ *
+ * On Windows, the most reliable way to detect a 64-bit OS from within a 32-bit
+ * app is based on the presence of a WOW64 file: %SystemRoot%\SysNative.
+ *
+ * Background: https://twitter.com/feross/status/776949077208510464
+ */
+function is64BitOperatingSystem () {
+  // This is a 64-bit binary, so the OS clearly supports 64-bit apps
+  if (process.arch === 'x64') return true
+
+  let useEnv = false
+  try {
+    useEnv = !!(process.env.SYSTEMROOT && fs.statSync(process.env.SYSTEMROOT))
+  } catch (err) {}
+
+  let sysRoot = useEnv ? process.env.SYSTEMROOT : 'C:\\Windows'
+
+  // If %SystemRoot%\SysNative exists, we are in a WOW64 FS Redirected application.
+  let isWOW64 = false
+  try {
+    isWOW64 = !!fs.statSync(path.join(sysRoot, 'sysnative'))
+  } catch (err) {}
+
+  return isWOW64
 }

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -11,7 +11,8 @@ const windows = require('./windows')
 
 const AUTO_UPDATE_URL = config.AUTO_UPDATE_URL +
   '?version=' + config.APP_VERSION +
-  '&platform=' + process.platform
+  '&platform=' + process.platform +
+  '&sysarch=' + config.OS_SYSARCH
 
 function init () {
   if (process.platform === 'linux') {

--- a/src/renderer/lib/telemetry.js
+++ b/src/renderer/lib/telemetry.js
@@ -105,6 +105,7 @@ function getSystemInfo () {
     osPlatform: process.platform,
     osRelease: os.type() + ' ' + os.release(),
     architecture: os.arch(),
+    systemArchitecture: config.OS_SYSARCH,
     totalMemoryMB: roundPow2(os.totalmem() / (1 << 20)),
     numCores: os.cpus().length
   }


### PR DESCRIPTION
Detect the actual operating system CPU architecture. This is different
than `process.arch` which returns the architecture the binary was
compiled for.

This is just good info to have in the telemetry, but we're also sending
it in the update check so that eventually we can upgrade Windows 32-bit
apps to 64-bit, like Slack does.

Context: https://github.com/feross/webtorrent-desktop/issues/873#issuecomment-247722023