### PR TITLE
Add 64-bit Windows build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # WebTorrent Desktop Version History
 
+## v0.16.0 - 2016-09-18
+
+### Added
+- **Windows 64-bit support!**
+  - Existing 32-bit users will update to 64-bit automatically in next release
+  - 64-bit reduces likelihood of out-of-memory errors by increasing the address space
+
 ## v0.15.0 - 2016-09-16
 
 ### Added

--- a/bin/package.js
+++ b/bin/package.js
@@ -462,8 +462,8 @@ function buildWin32 (cb) {
 
           // WebTorrent-vX.X.X-full.nupkg -> WebTorrent-vX.X.X-ia32-full.nupkg
           fs.renameSync(
-            path.join(DIST_PATH, `${config.BUILD_NAME}-full.nupkg`),
-            path.join(DIST_PATH, `${config.BUILD_NAME}-ia32-full.nupkg`)
+            path.join(DIST_PATH, `${BUILD_NAME}-full.nupkg`),
+            path.join(DIST_PATH, `${BUILD_NAME}-ia32-full.nupkg`)
           )
 
           // Change file name inside RELEASES-ia32 to match renamed file

--- a/bin/package.js
+++ b/bin/package.js
@@ -468,8 +468,13 @@ function buildWin32 (cb) {
 
           // Change file name inside RELEASES-ia32 to match renamed file
           var relContent = fs.readFileSync(relPath, 'utf8')
-          relContent = relContent.replace(/full\.nupkg$/, '-ia32-full.nupkg')
-          fs.writeFileSync(relPath, relContent)
+          var relContent32 = relContent.replace(/full\.nupkg$/, '-ia32-full.nupkg')
+          fs.writeFileSync(relPath, relContent32)
+
+          if (relContent === relContent32) {
+            // Sanity check
+            throw new Error('Fixing RELEASE-ia32 failed. Replacement did not modify the file.')
+          }
 
           console.log('Windows: Renamed ia32 installer files.')
         }

--- a/bin/package.js
+++ b/bin/package.js
@@ -112,7 +112,7 @@ var darwin = {
   // Build for Mac
   platform: 'darwin',
 
-  // Build 64 bit binaries only.
+  // Build x64 binaries only.
   arch: 'x64',
 
   // The bundle identifier to use in the application's plist (Mac only).
@@ -133,8 +133,8 @@ var win32 = {
   // Build for Windows.
   platform: 'win32',
 
-  // Build 32 bit binaries only.
-  arch: 'ia32',
+  // Build ia32 and x64 binaries.
+  arch: 'all',
 
   // Object hash of application metadata to embed into the executable (Windows only)
   'version-string': {
@@ -167,7 +167,7 @@ var linux = {
   // Build for Linux.
   platform: 'linux',
 
-  // Build 32 and 64 bit binaries.
+  // Build ia32 and x64 binaries.
   arch: 'all'
 
   // Note: Application icon for Linux is specified via the BrowserWindow `icon` option.
@@ -388,19 +388,25 @@ function buildWin32 (cb) {
     }
 
     var tasks = []
-    if (argv.package === 'exe' || argv.package === 'all') {
-      tasks.push((cb) => packageInstaller(cb))
-    }
-    if (argv.package === 'portable' || argv.package === 'all') {
-      tasks.push((cb) => packagePortable(cb))
-    }
+    buildPath.forEach(function (filesPath) {
+      var destArch = filesPath.split('-').pop()
+
+      if (argv.package === 'exe' || argv.package === 'all') {
+        tasks.push((cb) => packageInstaller(filesPath, destArch, cb))
+      }
+      if (argv.package === 'portable' || argv.package === 'all') {
+        tasks.push((cb) => packagePortable(filesPath, destArch, cb))
+      }
+    })
     series(tasks, cb)
 
-    function packageInstaller (cb) {
-      console.log('Windows: Creating installer...')
+    function packageInstaller (filesPath, destArch, cb) {
+      console.log(`Windows: Creating ${destArch} installer...`)
+
+      var archStr = destArch === 'ia32' ? '-ia32' : ''
 
       installer.createWindowsInstaller({
-        appDirectory: buildPath[0],
+        appDirectory: filesPath,
         authors: config.APP_TEAM,
         description: config.APP_NAME,
         exe: config.APP_NAME + '.exe',
@@ -410,8 +416,21 @@ function buildWin32 (cb) {
         noMsi: true,
         outputDirectory: DIST_PATH,
         productName: config.APP_NAME,
-        remoteReleases: config.GITHUB_URL,
-        setupExe: config.APP_NAME + 'Setup-v' + config.APP_VERSION + '.exe',
+        /**
+         * Only create delta updates for the Windows x64 build because 90% of our
+         * users have Windows x64 and the delta files take a *very* long time to
+         * generate. Also, the ia32 files on GitHub have non-standard Squirrel
+         * names (i.e. RELEASES-ia32 instead of RELEASES) and so Squirrel won't
+         * find them unless we proxy the requests.
+         */
+        remoteReleases: destArch === 'x64'
+          ? config.GITHUB_URL
+          : undefined,
+        /**
+         * If you hit a "GitHub API rate limit exceeded" error, set this token!
+         */
+        remoteToken: process.env.WEBTORRENT_GITHUB_API_TOKEN,
+        setupExe: config.APP_NAME + 'Setup-v' + config.APP_VERSION + archStr + '.exe',
         setupIcon: config.APP_ICON + '.ico',
         signWithParams: signWithParams,
         title: config.APP_NAME,
@@ -419,23 +438,61 @@ function buildWin32 (cb) {
         version: pkg.version
       })
       .then(function () {
-        console.log('Windows: Created installer.')
+        console.log(`Windows: Created ${destArch} installer.`)
+
+        /**
+         * Delete extraneous Squirrel files (i.e. *.nupkg delta files for older
+         * versions of the app)
+         */
+        fs.readdirSync(DIST_PATH)
+          .filter((name) => name.endsWith('.nupkg') && !name.includes(pkg.version))
+          .forEach((filename) => {
+            fs.unlinkSync(path.join(DIST_PATH, filename))
+          })
+
+        if (destArch === 'ia32') {
+          /**
+           * Rename ia32 Squirrel files to contain "-ia32". Specifically:
+           *   - RELEASES -> RELEASES-ia32
+           *   - WebTorrent-x.x.x-delta.nupkg -> WebTorrent-x.x.x-delta-ia32.nupkg
+           *   - WebTorrent-x.x.x-full.nupkg -> WebTorrent-x.x.x-full-ia32.nupkg
+           */
+          console.log('Windows: Renaming ia32 installer files...')
+
+          fs.renameSync(
+            path.join(DIST_PATH, 'RELEASES'),
+            path.join(DIST_PATH, 'RELEASES-ia32')
+          )
+          fs.readdirSync(DIST_PATH)
+            .filter((filename) => filename.endsWith('.nupkg'))
+            .forEach((filename) => {
+              fs.renameSync(
+                path.join(DIST_PATH, filename),
+                path.join(DIST_PATH, filename.replace(/\.nupkg$/, '-ia32.nupkg'))
+              )
+            })
+
+          console.log('Windows: Renamed ia32 installer files.')
+        }
+
         cb(null)
       })
       .catch(cb)
     }
 
-    function packagePortable (cb) {
-      console.log('Windows: Creating portable app...')
+    function packagePortable (filesPath, destArch, cb) {
+      console.log(`Windows: Creating ${destArch} portable app...`)
 
-      var portablePath = path.join(buildPath[0], 'Portable Settings')
+      var portablePath = path.join(filesPath, 'Portable Settings')
       mkdirp.sync(portablePath)
 
-      var inPath = path.join(DIST_PATH, path.basename(buildPath[0]))
-      var outPath = path.join(DIST_PATH, BUILD_NAME + '-win.zip')
+      var archStr = destArch === 'ia32' ? '-ia32' : ''
+
+      var inPath = path.join(DIST_PATH, path.basename(filesPath))
+      var outPath = path.join(DIST_PATH, BUILD_NAME + '-win' + archStr + '.zip')
       zip.zipSync(inPath, outPath)
 
-      console.log('Windows: Created portable app.')
+      console.log(`Windows: Created ${destArch} portable app.`)
       cb(null)
     }
   })
@@ -500,8 +557,10 @@ function buildLinux (cb) {
     // Create .zip file for Linux
     console.log(`Linux: Creating ${destArch} zip...`)
 
+    var archStr = destArch === 'ia32' ? '-ia32' : ''
+
     var inPath = path.join(DIST_PATH, path.basename(filesPath))
-    var outPath = path.join(DIST_PATH, BUILD_NAME + '-linux-' + destArch + '.zip')
+    var outPath = path.join(DIST_PATH, BUILD_NAME + '-linux' + archStr + '.zip')
     zip.zipSync(inPath, outPath)
 
     console.log(`Linux: Created ${destArch} zip.`)

--- a/bin/package.js
+++ b/bin/package.js
@@ -451,26 +451,25 @@ function buildWin32 (cb) {
           })
 
         if (destArch === 'ia32') {
-          /**
-           * Rename ia32 Squirrel files to contain "-ia32". Specifically:
-           *   - RELEASES -> RELEASES-ia32
-           *   - WebTorrent-x.x.x-delta.nupkg -> WebTorrent-x.x.x-delta-ia32.nupkg
-           *   - WebTorrent-x.x.x-full.nupkg -> WebTorrent-x.x.x-full-ia32.nupkg
-           */
           console.log('Windows: Renaming ia32 installer files...')
 
+          // RELEASES -> RELEASES-ia32
+          var relPath = path.join(DIST_PATH, 'RELEASES-ia32')
           fs.renameSync(
             path.join(DIST_PATH, 'RELEASES'),
-            path.join(DIST_PATH, 'RELEASES-ia32')
+            relPath
           )
-          fs.readdirSync(DIST_PATH)
-            .filter((filename) => filename.endsWith('.nupkg'))
-            .forEach((filename) => {
-              fs.renameSync(
-                path.join(DIST_PATH, filename),
-                path.join(DIST_PATH, filename.replace(/\.nupkg$/, '-ia32.nupkg'))
-              )
-            })
+
+          // WebTorrent-vX.X.X-full.nupkg -> WebTorrent-vX.X.X-ia32-full.nupkg
+          fs.renameSync(
+            path.join(DIST_PATH, `${config.BUILD_NAME}-full.nupkg`),
+            path.join(DIST_PATH, `${config.BUILD_NAME}-ia32-full.nupkg`)
+          )
+
+          // Change file name inside RELEASES-ia32 to match renamed file
+          var relContent = fs.readFileSync(relPath, 'utf8')
+          relContent = relContent.replace(/full\.nupkg$/, '-ia32-full.nupkg')
+          fs.writeFileSync(relPath, relContent)
 
           console.log('Windows: Renamed ia32 installer files.')
         }

--- a/static/about.html
+++ b/static/about.html
@@ -32,6 +32,7 @@
     <p>
       Version <script>document.write(require('../package.json').version)</script>
       (<script>document.write(require('webtorrent/package.json').version)</script>)
+      (<script>document.write(process.arch === 'x64' ? '64-bit' : '32-bit')</script>)
     </p>
     <p><script>document.write(require('../config').APP_COPYRIGHT)</script></p>
   </body>


### PR DESCRIPTION
Right now all Windows users are running a 32-bit app, even if their OS
is 64-bit. This means that the app is limited to a 4GB address space,
which may be contributing to the "Array buffer allocation failed" errors
we are seeing in the wild (#873).

If users on Windows 64-bit (90%+ of users) could run a 64-bit app,
they're less likely to run into out-of-memory errors.

Here's the plan to improve things:

1. We release a 64-bit installer, in addition to the 32-bit installer.

2. We auto-detect in the browser when a visitor is on a 32-bit vs.
64-bit OS and try to offer them the right installer. When in doubt, we
give them the 32-bit installer since that's safest.

3. The auto-updater will return the right binaries for the architecture
the user is on. This means that all our existing users who have 64-bit
OSs but are running the 32-bit app will get updated to the 64-bit app
on the next update. Also, 64-bit users who accidentally download the
32-bit installer will also get the 64-bit app on the next update.

---

Other notes:

- We don't generate 32-bit delta files. See reasoning inline.
- The package script now deletes extraneous Squirrel files (i.e.
*.nupkg delta files for older versions of the app) which should make
uploading the right files to GitHub easier. :)

The binary file naming works like this:

- Most users are on 64-bit systems, so they get nice clean file names
that don't specify an architecture (WebTorrentSetup-v1.0.0.exe). The
32-bit build files have the same naming but contain the string "-ia32"
at the end. In a few years, we will be able to just stop producing the
32-bit build files entirely.

- This means that the "WebTorrent-v0.15.0-linux-x64.zip" linux build
file is changing to "WebTorrent-v0.15.0-linux.zip" to match the Windows
naming convention. The .deb installer files must contain to
architecture in order to install correctly, so those do not change.

- Mac is 100% 64-bit, so it does not change.