### PR TITLE
Replace babel with bublé

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -39,9 +39,9 @@ function build () {
   rimraf.sync(DIST_PATH)
   rimraf.sync(BUILD_PATH)
 
-  console.log('Babel: Building JSX...')
+  console.log('Build: Transpiling to ES5...')
   cp.execSync('npm run build', { NODE_ENV: 'production', stdio: 'inherit' })
-  console.log('Babel: Built JSX.')
+  console.log('Build: Transpiled to ES5.')
 
   var platform = argv._[0]
   if (platform === 'darwin') {

--- a/package.json
+++ b/package.json
@@ -49,11 +49,7 @@
     "zero-fill": "^2.2.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.11.4",
-    "babel-plugin-syntax-jsx": "^6.13.0",
-    "babel-plugin-transform-es2015-destructuring": "^6.9.0",
-    "babel-plugin-transform-object-rest-spread": "^6.8.0",
-    "babel-plugin-transform-react-jsx": "^6.8.0",
+    "buble": "^0.14.0",
     "cross-zip": "^2.0.1",
     "depcheck": "^0.6.4",
     "electron-osx-sign": "^0.3.0",
@@ -99,14 +95,14 @@
     "url": "git://github.com/feross/webtorrent-desktop.git"
   },
   "scripts": {
-    "build": "babel --quiet src --out-dir build",
+    "build": "buble src --output build",
     "clean": "node ./bin/clean.js",
     "open-config": "node ./bin/open-config.js",
     "package": "node ./bin/package.js",
     "prepublish": "npm run build",
     "start": "npm run build && electron .",
     "integration-test": "npm run build && node ./test",
-    "test": "standard && depcheck --ignores=babel-cli,nodemon,gh-release --ignore-dirs=build,dist && node ./bin/extra-lint.js",
+    "test": "standard && depcheck --ignores=buble,nodemon,gh-release --ignore-dirs=build,dist && node ./bin/extra-lint.js",
     "gh-release": "gh-release",
     "update-authors": "./bin/update-authors.sh",
     "watch": "nodemon --exec \"npm run start\" --ext js,pug,css"

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "syntax-jsx",
-    "transform-es2015-destructuring",
-    "transform-object-rest-spread",
-    "transform-react-jsx"
-  ]
-}


### PR DESCRIPTION
Fixes https://github.com/feross/webtorrent-desktop/issues/940

Pros of [`buble`](https://buble.surge.sh/) over `babel`:

- No configuration (a la standard)
- Runs twice as fast, for quicker development
- Converts everything to ES5 (which is likely to be faster than ES6,
but this is untested)
- Easy to swap Babel back in -- low commitment

Cons:
- Less battle-tested than Babel, but recommended by React core
developer so probably not too bad
- No babel plugin support, but we're not using that right now anyway.
Can switch back to babel if we need that later

BEFORE:

$ time npm run build

> webtorrent-desktop@0.16.0 build /Users/feross/code/webtorrent-desktop
> babel --quiet src --out-dir build

npm run build  3.07s user 0.27s system 115% cpu 2.902 total

AFTER:

$ time npm run build

> webtorrent-desktop@0.16.0 build /Users/feross/code/webtorrent-desktop
> buble src --output build

npm run build  1.38s user 0.16s system 114% cpu 1.343 total