### PR TITLE
Update electron-packager to v8

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -73,11 +73,11 @@ var all = {
   // Package the application's source code into an archive, using Electron's archive
   // format. Mitigates issues around long path names on Windows and slightly speeds up
   // require().
-  asar: true,
-
-  // A glob expression, that unpacks the files with matching names to the
-  // "app.asar.unpacked" directory.
-  'asar-unpack': 'WebTorrent*',
+  asar: {
+    // A glob expression, that unpacks the files with matching names to the
+    // "app.asar.unpacked" directory.
+    unpack: 'WebTorrent*'
+  },
 
   // The build version of the application. Maps to the FileVersion metadata property on
   // Windows, and CFBundleVersion on Mac. Note: Windows requires the build version to
@@ -137,7 +137,7 @@ var win32 = {
   arch: 'all',
 
   // Object hash of application metadata to embed into the executable (Windows only)
-  'version-string': {
+  win32metadata: {
 
     // Company that produced the file.
     CompanyName: config.APP_NAME,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cross-zip": "^2.0.1",
     "depcheck": "^0.6.4",
     "electron-osx-sign": "^0.3.0",
-    "electron-packager": "^7.0.0",
+    "electron-packager": "^8.0.0",
     "electron-winstaller": "^2.3.0",
     "gh-release": "^2.0.3",
     "minimist": "^1.2.0",


### PR DESCRIPTION
This doesn't add anything new that we need, but it deleted some deprecated features, so let's update.

Changelog: https://github.com/electron-userland/electron-packager/blob/master/NEWS.md#800---2016-09-03