### PR TITLE
Wait for 'ready-to-show' event before showing window

### DIFF
--- a/src/main/windows/about.js
+++ b/src/main/windows/about.js
@@ -32,7 +32,7 @@ function init () {
   // No menu on the About window
   win.setMenu(null)
 
-  win.webContents.once('did-finish-load', function () {
+  win.once('ready-to-show', function () {
     win.show()
   })
 

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -38,11 +38,15 @@ function init (state, options) {
     title: config.APP_WINDOW_TITLE,
     titleBarStyle: 'hidden-inset', // Hide title bar (Mac)
     useContentSize: true, // Specify web page size without OS chrome
-    show: !options.hidden,
+    show: false,
     width: initialBounds.width,
     height: initialBounds.height,
     x: initialBounds.x,
     y: initialBounds.y
+  })
+
+  win.once('ready-to-show', function () {
+    if (!options.hidden) win.show()
   })
 
   win.loadURL(config.WINDOW_MAIN)


### PR DESCRIPTION
This gets rid of the light gray to dark gray background color change on
the main window at startup. Makes the window show slightly later, but
it's gray for less time. Doesn't affect overall startup time. Feels
less jank IMO.

From the Electron docs:

> While loading the page, the 'ready-to-show' event will be emitted
when renderer process has done drawing for the first time, showing
window after this event will have no visual flash.