### PR TITLE
Add more peer ID entropy

### DIFF
--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -56,12 +56,8 @@ const VERSION_PREFIX = '-WD' + VERSION_STR + '-'
 
 /**
  * Generate an ephemeral peer ID each time.
- * Once there are around 2^24 = ~8 million WebTorrent Desktops online at the same time,
- * ID collisions will start happening. Birthday paradox.
- * This is fine, though. Bad peers can already clone someone else's peer ID.
- * The network is robust to occasional collisions.
  */
-const PEER_ID = Buffer.from(VERSION_PREFIX + crypto.randomBytes(6).toString('hex'))
+const PEER_ID = Buffer.from(VERSION_PREFIX + crypto.randomBytes(9).toString('base64'))
 
 // Connect to the WebTorrent and BitTorrent networks. WebTorrent Desktop is a hybrid
 // client, as explained here: https://webtorrent.io/faq


### PR DESCRIPTION
This still keeps the peer ID printable as ascii, while adding lots more entropy