### PR TITLE
set status to Idle if paused

### DIFF
--- a/src/renderer/pages/torrent-list-page.js
+++ b/src/renderer/pages/torrent-list-page.js
@@ -174,7 +174,10 @@ module.exports = class TorrentList extends React.Component {
     }
 
     function renderTorrentStatus () {
-      return (<span>{capitalize(torrentSummary.status)}</span>)
+      let status = torrentSummary.status === 'paused'
+        ? 'Idle'
+        : capitalize(torrentSummary.status)
+      return (<span>{status}</span>)
     }
   }
 


### PR DESCRIPTION
"Paused" status is a bit confusing to show on the torrent list, especially since it means something different if on the player view.

This PR changes it to say "Idle" instead, which helps convey the torrent state better and avoids using the same word for two things.

...just floating this PR out as an idea. If its not something we should do go ahead and close it :)

Screenshot:
![image](https://cloud.githubusercontent.com/assets/360233/18799308/9213329a-819c-11e6-975f-ec1bca64578d.png)
