### PR TITLE
Fix Windows Portable App mode

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,8 +12,8 @@ const IS_TEST = isTest()
 const PORTABLE_PATH = IS_TEST
   ? path.join(process.platform === 'win32' ? 'C:\\Windows\\Temp' : '/tmp', 'WebTorrentTest')
   : path.join(path.dirname(process.execPath), 'Portable Settings')
-const IS_PORTABLE = isPortable()
 const IS_PRODUCTION = isProduction()
+const IS_PORTABLE = isPortable()
 
 const UI_HEADER_HEIGHT = 38
 const UI_TORRENT_HEIGHT = 100
@@ -141,11 +141,18 @@ function isPortable () {
   if (IS_TEST) {
     return true
   }
-  try {
-    return process.platform === 'win32' && IS_PRODUCTION && !!fs.statSync(PORTABLE_PATH)
-  } catch (err) {
+
+  if (process.platform !== 'win32' || !IS_PRODUCTION) {
+    // Fast path: Non-Windows platforms should not check for path on disk
     return false
   }
+
+  let portablePathExists = false
+  try {
+    portablePathExists = !!fs.statSync(PORTABLE_PATH)
+  } catch (err) {}
+
+  return portablePathExists
 }
 
 function isProduction () {


### PR DESCRIPTION
Fixes: #971

This is a perfect example of putting too many statements into a
try-catch block. My bad. I was trying to keep the code simple, but it
bit us here.

This happens because we were using IS_PRODUCTION, but the order of the
consts at the top are:

const IS_PORTABLE = isPortable()
const IS_PRODUCTION = isProduction()

So we're inside of isPortable() and referring to IS_PRODUCTION before
it's defined. This should have thrown an exception, but it was caught by 
the try-catch block. 

Also, even after moving it out of the try-catch block, it still doesn't throw
an exception because we're transforming to ES5, so the consts are
changed to vars.

Also, standard should have caught this, but there's this bug https://github.com/feross/standard/issues/636 that is preventing
us from enabling the `use-before-define` rule. Will hopefully be fixed
soon.

Basically, a perfect storm.