### PR TITLE
Fix "Download path missing" for Portable App first run

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -490,6 +490,9 @@ function buildWin32 (cb) {
       var portablePath = path.join(filesPath, 'Portable Settings')
       mkdirp.sync(portablePath)
 
+      var downloadsPath = path.join(portablePath, 'Downloads')
+      mkdirp.sync(downloadsPath)
+
       var archStr = destArch === 'ia32' ? '-ia32' : ''
 
       var inPath = path.join(DIST_PATH, path.basename(filesPath))


### PR DESCRIPTION
Create "Portable Settings\Downloads" folder to prevent "Download path
missing" warning, on Windows.

<img width="447" alt="screen shot 2016-09-27 at 1 02 37 pm" src="https://cloud.githubusercontent.com/assets/121766/18889905/f38e355a-84b3-11e6-90a3-e4efa3931e9b.png">
