### PR TITLE
Make Portable App also a Silent App

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Builds app binaries for Mac, Linux, and Windows.
+ * Builds app binaries for Mac, Windows, and Linux.
  */
 
 var cp = require('child_process')
@@ -492,6 +492,9 @@ function buildWin32 (cb) {
 
       var downloadsPath = path.join(portablePath, 'Downloads')
       mkdirp.sync(downloadsPath)
+
+      var tempPath = path.join(portablePath, 'Temp')
+      mkdirp.sync(tempPath)
 
       var archStr = destArch === 'ia32' ? '-ia32' : ''
 

--- a/src/config.js
+++ b/src/config.js
@@ -116,9 +116,7 @@ function getConfigPath () {
 }
 
 function getDefaultDownloadPath () {
-  if (!process || !process.type) {
-    return ''
-  } else if (IS_PORTABLE) {
+  if (IS_PORTABLE) {
     return path.join(getConfigPath(), 'Downloads')
   } else {
     return getPath('downloads')
@@ -126,9 +124,14 @@ function getDefaultDownloadPath () {
 }
 
 function getPath (key) {
-  if (process.type === 'renderer') {
+  if (!process.versions.electron) {
+    // Node.js process
+    return ''
+  } else if (process.type === 'renderer') {
+    // Electron renderer process
     return electron.remote.app.getPath(key)
   } else {
+    // Electron main process
     return electron.app.getPath(key)
   }
 }
@@ -159,6 +162,7 @@ function isPortable () {
 
 function isProduction () {
   if (!process.versions.electron) {
+    // Node.js process
     return false
   }
   if (process.platform === 'darwin') {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -33,9 +33,11 @@ if (process.platform === 'win32') {
   argv = argv.filter((arg) => !arg.includes('--squirrel'))
 }
 
-if (!shouldQuit) {
+if (!shouldQuit && !config.IS_PORTABLE) {
   // Prevent multiple instances of app from running at same time. New instances
-  // signal this instance and quit.
+  // signal this instance and quit. Note: This feature creates a lock file in
+  // %APPDATA%\Roaming\WebTorrent so we do not do it for the Portable App since
+  // we want to be "silent" as well as "portable".
   shouldQuit = app.makeSingleInstance(onAppOpen)
   if (shouldQuit) {
     app.quit()
@@ -48,7 +50,11 @@ if (!shouldQuit) {
 
 function init () {
   if (config.IS_PORTABLE) {
+    const path = require('path')
+    // Put all user data into the "Portable Settings" folder
     app.setPath('userData', config.CONFIG_PATH)
+    // Put Electron crash files, etc. into the "Portable Settings\Temp" folder
+    app.setPath('temp', path.join(config.CONFIG_PATH, 'Temp'))
   }
 
   const ipcMain = electron.ipcMain


### PR DESCRIPTION
Fixes two portable app bugs, to make the app fully "silent", not just
"portable". This means that not only are all data files stored in the
"Portable Settings" folder, but the app should leave no trace on the
host system.

- Disable Electron's single instance mode so no lock file is created in
"%APPDATA%\Roaming\WebTorrent".

- Put Electron crash files, and other electron files into the "Portable
Settings\Temp" folder instead of "%APPDATA%\Temp".