### PR TITLE
Remove `.nodemonignore` file.

### DIFF
--- a/.nodemonignore
+++ b/.nodemonignore
@@ -1,2 +1,0 @@
-build/
-dist/

--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
     "test": "standard && depcheck --ignores=buble,nodemon,gh-release --ignore-dirs=build,dist && node ./bin/extra-lint.js",
     "gh-release": "gh-release",
     "update-authors": "./bin/update-authors.sh",
-    "watch": "nodemon --exec \"npm run start\" --ext js,pug,css"
+    "watch": "nodemon --exec \"npm run start\" --ext js,pug,css --ignore build/ --ignore dist/"
   }
 }


### PR DESCRIPTION
Adding configuration files for every tool used will clutter up the repository, especially for a configuration as simple as this.