### PR TITLE
Delay external player if server is not ready

### DIFF
--- a/src/renderer/controllers/media-controller.js
+++ b/src/renderer/controllers/media-controller.js
@@ -56,12 +56,18 @@ module.exports = class MediaController {
 
   openExternalPlayer () {
     const state = this.state
-    const mediaURL = Playlist.getCurrentLocalURL(this.state)
-    ipcRenderer.send('openExternalPlayer',
-      state.saved.prefs.externalPlayerPath,
-      mediaURL,
-      state.window.title)
     state.playing.location = 'external'
+
+    let open = function () {
+      const mediaURL = Playlist.getCurrentLocalURL(state)
+      ipcRenderer.send('openExternalPlayer',
+        state.saved.prefs.externalPlayerPath,
+        mediaURL,
+        state.window.title)
+    }
+
+    if (state.server != null) open()
+    else ipcRenderer.once('wt-server-running', open)
   }
 
   externalPlayerNotFound () {


### PR DESCRIPTION
Fixes #984.
Since we are going straight to the player now, a race condition can occur where the media server is not running before spawning the external player.