### PR TITLE
Go back to list on path missing error

### DIFF
--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -93,6 +93,7 @@ module.exports = class TorrentListController {
     fs.stat(fileOrFolder, function (err) {
       if (err) {
         s.error = 'path-missing'
+        dispatch('backToList')
         return
       }
       start()


### PR DESCRIPTION
Fixes issue mentioned by @demoneaux https://github.com/feross/webtorrent-desktop/issues/816#issuecomment-250070097.