### PR TITLE
Improve paste handling

### DIFF
--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -101,7 +101,7 @@ module.exports = class TorrentListController {
     function start () {
       ipcRenderer.send('wt-start-torrenting',
         s.torrentKey,
-        TorrentSummary.getTorrentID(s),
+        TorrentSummary.getTorrentId(s),
         s.path,
         s.fileModtimes,
         s.selections)

--- a/src/renderer/controllers/torrent-list-controller.js
+++ b/src/renderer/controllers/torrent-list-controller.js
@@ -25,6 +25,11 @@ module.exports = class TorrentListController {
       torrentId = torrentId.path
     }
 
+    // Trim extra spaces off pasted magnet links
+    if (typeof torrentId === 'string') {
+      torrentId = torrentId.trim()
+    }
+
     // Allow a instant.io link to be pasted
     if (typeof torrentId === 'string' && instantIoRegex.test(torrentId)) {
       torrentId = torrentId.slice(torrentId.indexOf('#') + 1)

--- a/src/renderer/lib/torrent-summary.js
+++ b/src/renderer/lib/torrent-summary.js
@@ -2,7 +2,7 @@ module.exports = {
   getPosterPath,
   getTorrentPath,
   getByKey,
-  getTorrentID,
+  getTorrentId,
   getFileOrFolder
 }
 
@@ -28,7 +28,7 @@ function getPosterPath (torrentSummary) {
 
 // Expects a torrentSummary
 // Returns a torrentID: filename, magnet URI, or infohash
-function getTorrentID (torrentSummary) {
+function getTorrentId (torrentSummary) {
   const s = torrentSummary
   if (s.torrentFileName) { // Load torrent file from disk
     return getTorrentPath(s)

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -429,14 +429,7 @@ function onError (err) {
 
 function onPaste (e) {
   if (e.target.tagName.toLowerCase() === 'input') return
-
-  const torrentIds = electron.clipboard.readText().split('\n')
-  torrentIds.forEach(function (torrentId) {
-    torrentId = torrentId.trim()
-    if (torrentId.length === 0) return
-    controllers.torrentList.addTorrent(torrentId)
-  })
-
+  controllers.torrentList.addTorrent(electron.clipboard.readText())
   update()
 }
 


### PR DESCRIPTION
On paste: Do not handle multiple newline separated torrent ids

- If the user accidentally pastes something that's not a torrent id, then they get one "Invalid torrent Id" error for each line of the text.

- Sure, this removes a "feature", but it's a pretty surprising one. When
I added it, I was being too clever, IMO.

Trim extra spaces off pasted magnet links

- Before this change, using the "Open Torrent Address" dialog to paste a
magnet link would fail with leading or trailing spaces.

- Pasting on the torrent list page has always trimmed. So this PR just
makes it consistent.