### PR TITLE
Remove weird outline from “Create Torrent” button.

### DIFF
--- a/src/renderer/pages/create-torrent-page.js
+++ b/src/renderer/pages/create-torrent-page.js
@@ -106,7 +106,7 @@ class CreateTorrentPage extends React.Component {
             }}
             onClick={dispatcher('cancel')} />
           <RaisedButton
-            className='control create-torrent'
+            className='control create-torrent-button'
             label='Create Torrent'
             primary
             onClick={this.handleSubmit} />

--- a/test/test-add-torrent.js
+++ b/test/test-add-torrent.js
@@ -70,7 +70,7 @@ test('create-torrent', function (t) {
     .then(() => app.client.waitUntilTextExists('.create-torrent-advanced', 'Comment'))
     .then(() => setup.screenshotCreateOrCompare(app, t, 'create-torrent-advanced'))
     // Click OK to create the torrent
-    .then(() => app.client.click('.control.create-torrent'))
+    .then(() => app.client.click('.control.create-torrent-button'))
     .then(() => app.client.waitUntilTextExists('.torrent-list', 'tmp.jpg'))
     .then(() => app.client.moveToObject('.torrent'))
     .then(() => setup.screenshotCreateOrCompare(app, t, 'create-torrent-100-percent'))


### PR DESCRIPTION
The outline was caused by the wrong class being applied to the button.

Closes #989.