### PR TITLE
cp-file@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bitfield": "^1.0.2",
     "capture-frame": "^1.0.0",
     "chromecasts": "^1.8.0",
-    "cp-file": "^3.2.0",
+    "cp-file": "^4.0.1",
     "create-torrent": "^3.24.5",
     "debounce": "^1.0.0",
     "deep-equal": "^1.0.1",


### PR DESCRIPTION
Only change is dropped Node 0.10 and 0.12 support. Nice change because
it means we load 3 fewer dependencies.