### PR TITLE
package: Explicitly specify architectures to build for

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -134,7 +134,7 @@ const win32 = {
   platform: 'win32',
 
   // Build ia32 and x64 binaries.
-  arch: 'all',
+  arch: ['ia32', 'x64'],
 
   // Object hash of application metadata to embed into the executable (Windows only)
   win32metadata: {
@@ -168,7 +168,7 @@ const linux = {
   platform: 'linux',
 
   // Build ia32 and x64 binaries.
-  arch: 'all'
+  arch: ['ia32', 'x64']
 
   // Note: Application icon for Linux is specified via the BrowserWindow `icon` option.
 }


### PR DESCRIPTION
Electron now offers a "armv7l" build on Linux. Because we were
specifying "all", we were generating an armv7l binary which was being
included in "WebTorrent-vX.X.X-linux.zip" along with the ia32 build,
which explains why it was 90MB+ in the last release.