### PR TITLE
Fix "Cannot read property 'files' of null"

### DIFF
--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -268,8 +268,16 @@ module.exports = class PlaybackController {
     state.playing.jumpToTime = jumpToTime
 
     // if it's audio, parse out the metadata (artist, title, etc)
-    if (state.playing.type === 'audio' && !fileSummary.audioInfo) {
-      ipcRenderer.send('wt-get-audio-metadata', torrentSummary.infoHash, index)
+    if (torrentSummary.status === 'paused') {
+      ipcRenderer.once('wt-ready-' + torrentSummary.infoHash, getAudioMetadata)
+    } else {
+      getAudioMetadata()
+    }
+
+    function getAudioMetadata () {
+      if (state.playing.type === 'audio' && !fileSummary.audioInfo) {
+        ipcRenderer.send('wt-get-audio-metadata', torrentSummary.infoHash, index)
+      }
     }
 
     // if it's video, check for subtitles files that are done downloading

--- a/src/renderer/webtorrent.js
+++ b/src/renderer/webtorrent.js
@@ -125,8 +125,6 @@ function startTorrenting (torrentKey, torrentID, path, fileModtimes, selections)
 
   // Only download the files the user wants, not necessarily all files
   torrent.once('ready', () => selectFiles(torrent, selections))
-
-  return torrent
 }
 
 function stopTorrenting (infoHash) {


### PR DESCRIPTION
This PR fixes our number 2 top error (142 error reports today
alone):

```
Processes: webtorrent window, platforms: darwin linux win32, versions:
pre-0.12 0.14.0 0.17.0 0.17.1
TypeError: Cannot read property 'files' of null
  at getAudioMetadata (.../build/renderer/webtorrent.js:328:21)
  at EventEmitter.<anonymous> (.../build/renderer/webtorrent.js:84:74)
  at emitThree (events.js:116:13)
  at EventEmitter.emit (events.js:194:7)
```

This error is reproducible if you start webtorrent for the first time
and click the WIRED CD torrent. This causes the renderer process to
send a  'wt-get-audio-metadata' before 'wt-start-torrenting' to the
webtorrent process.

You can reproduce it 100% of the time if you force the race condition
to show itself by slowing down the sending of the 'wt-start-torrenting'
event.

(This same error was showing for an unrelated reason in the past: #891)