### PR TITLE
Playback telemetry

### DIFF
--- a/src/renderer/controllers/media-controller.js
+++ b/src/renderer/controllers/media-controller.js
@@ -1,7 +1,5 @@
-const electron = require('electron')
-
-const ipcRenderer = electron.ipcRenderer
-
+const {ipcRenderer} = require('electron')
+const telemetry = require('../lib/telemetry')
 const Playlist = require('../lib/playlist')
 
 // Controls local play back: the <video>/<audio> tag and VLC
@@ -12,7 +10,7 @@ module.exports = class MediaController {
   }
 
   mediaSuccess () {
-    this.state.playing.result = 'success'
+    telemetry.logPlayAttempt('success')
   }
 
   mediaStalled () {
@@ -22,7 +20,7 @@ module.exports = class MediaController {
   mediaError (error) {
     const state = this.state
     if (state.location.url() === 'player') {
-      state.playing.result = 'error'
+      telemetry.logPlayAttempt('error')
       state.playing.location = 'error'
       ipcRenderer.send('checkForExternalPlayer', state.saved.prefs.externalPlayerPath)
       ipcRenderer.once('checkForExternalPlayer', function (e, isInstalled) {

--- a/src/renderer/controllers/media-controller.js
+++ b/src/renderer/controllers/media-controller.js
@@ -56,7 +56,10 @@ module.exports = class MediaController {
     const state = this.state
     state.playing.location = 'external'
 
-    let open = function () {
+    const onServerRunning = function () {
+      state.playing.isReady = true
+      telemetry.logPlayAttempt('external')
+
       const mediaURL = Playlist.getCurrentLocalURL(state)
       ipcRenderer.send('openExternalPlayer',
         state.saved.prefs.externalPlayerPath,
@@ -64,8 +67,8 @@ module.exports = class MediaController {
         state.window.title)
     }
 
-    if (state.server != null) open()
-    else ipcRenderer.once('wt-server-running', open)
+    if (state.server != null) onServerRunning()
+    else ipcRenderer.once('wt-server-running', onServerRunning)
   }
 
   externalPlayerNotFound () {

--- a/src/renderer/controllers/playback-controller.js
+++ b/src/renderer/controllers/playback-controller.js
@@ -223,6 +223,8 @@ module.exports = class PlaybackController {
 
   // Starts WebTorrent server for media streaming
   startServer (torrentSummary) {
+    const state = this.state
+
     if (torrentSummary.status === 'paused') {
       dispatch('startTorrentingSummary', torrentSummary.torrentKey)
       ipcRenderer.once('wt-ready-' + torrentSummary.infoHash,
@@ -233,7 +235,7 @@ module.exports = class PlaybackController {
 
     function onTorrentReady () {
       ipcRenderer.send('wt-start-server', torrentSummary.infoHash)
-      ipcRenderer.once('wt-server-running', () => state.playing.isReady = true)
+      ipcRenderer.once('wt-server-running', () => { state.playing.isReady = true })
     }
   }
 

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -91,7 +91,8 @@ function getDefaultPlayState () {
     location: 'local', /* 'local', 'chromecast', 'airplay' */
     type: null, /* 'audio' or 'video', could be 'other' if ever support eg streaming to VLC */
     currentTime: 0, /* seconds */
-    duration: 1, /* seconds */
+    duration: 1, /* seconds */,
+    isReady: false,
     isPaused: true,
     isStalled: false,
     lastTimeUpdate: 0, /* Unix time in ms */

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -91,7 +91,7 @@ function getDefaultPlayState () {
     location: 'local', /* 'local', 'chromecast', 'airplay' */
     type: null, /* 'audio' or 'video', could be 'other' if ever support eg streaming to VLC */
     currentTime: 0, /* seconds */
-    duration: 1, /* seconds */,
+    duration: 1, /* seconds */
     isReady: false,
     isPaused: true,
     isStalled: false,

--- a/src/renderer/lib/telemetry.js
+++ b/src/renderer/lib/telemetry.js
@@ -67,6 +67,7 @@ function reset () {
     total: 0,
     success: 0,
     error: 0,
+    external: 0,
     abandoned: 0
   }
 }
@@ -209,10 +210,10 @@ function getElemString (elem) {
   return ret
 }
 
-// The user pressed play. It either worked or showed the
-// 'Play in VLC' codec error
+// The user pressed play. Did it work, display an error,
+// open an external player or did user abandon the attempt?
 function logPlayAttempt (result) {
-  if (!['success', 'error', 'abandoned'].includes(result)) {
+  if (!['success', 'error', 'external', 'abandoned'].includes(result)) {
     return console.error('Unknown play attempt result', result)
   }
 

--- a/src/renderer/lib/telemetry.js
+++ b/src/renderer/lib/telemetry.js
@@ -66,7 +66,6 @@ function reset () {
     minVersion: config.APP_VERSION,
     total: 0,
     success: 0,
-    timeout: 0,
     error: 0,
     abandoned: 0
   }
@@ -210,10 +209,10 @@ function getElemString (elem) {
   return ret
 }
 
-// The user pressed play. It either worked, timed out, or showed the
+// The user pressed play. It either worked or showed the
 // 'Play in VLC' codec error
 function logPlayAttempt (result) {
-  if (!['success', 'timeout', 'error', 'abandoned'].includes(result)) {
+  if (!['success', 'error', 'abandoned'].includes(result)) {
     return console.error('Unknown play attempt result', result)
   }
 


### PR DESCRIPTION
Relates to #906.

Log play attempt for each item in playlist separately, instead of doing it only once on player close. Include information about external playbacks.