### PR TITLE
Fix 'About WebTorrent' menu location on Windows

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -408,7 +408,7 @@ function getMenuTemplate () {
       })
 
     // Help menu (Windows, Linux)
-    template[4].submenu.push(
+    template[5].submenu.push(
       {
         type: 'separator'
       },


### PR DESCRIPTION
Fixes this issue:

<img width="441" alt="screen shot 2017-02-03 at 2 50 10 am" src="https://cloud.githubusercontent.com/assets/121766/22588959/daec6f44-e9bc-11e6-8154-1c6e12788b74.png">
