### PR TITLE
Replace release scripts with instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ standard guarded open source project.
 
 There are a few basic ground-rules for contributors:
 
-1. **No `--force` pushes** or modifying the Git history in any way.
+1. **No `--force` pushes to master** or modifying history in any way. Rebasing and force pushing your own PR branch is fine.
 2. **Non-master branches** should be used for ongoing work.
 3. **Significant modifications** like API changes should be subject to a **pull request**
    to solicit feedback from other contributors.
@@ -73,23 +73,3 @@ By making a contribution to this project, I certify that:
   record of the contribution (including all personal information I submit with it,
   including my sign-off) is maintained indefinitely and may be redistributed consistent
   with this project or the open source license(s) involved.
-
-## Smoke Tests
-
-Before a release, check that the following basic use cases work correctly:
-
-1. Click "Play" to stream a built-in torrent (e.g. Sintel)
-  - Ensure that seeking to undownloaded region works and plays immediately.
-  - Ensure that sintel.mp4 gets downloaded to `~/Downloads`.
-
-2. Check that the auto-updater works
-  - Open the console and check for the line "No update available" to indicate
-
-3. Add a new .torrent file via drag-and-drop.
-  - Ensure that it gets added to the list and starts downloading
-
-4. Remove a torrent from the client
-  - Ensure that the file is removed from `~/Downloads`
-
-5. Create and seed a new a torrent via drag-and-drop.
-  - Ensure that the torrent gets created and seeding begins.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <h1 align="center">
   <br>
-  <a href="https://webtorrent.io"><img src="https://webtorrent.io/img/WebTorrent.png" alt="WebTorrent" width="200"></a>
+  <a href="https://webtorrent.io">
+    <img src="https://webtorrent.io/img/WebTorrent.png" alt="WebTorrent" width="200">
+  </a>
   <br>
   WebTorrent Desktop
   <br>
@@ -10,9 +12,15 @@
 <h4 align="center">The streaming torrent app. For Mac, Windows, and Linux.</h4>
 
 <p align="center">
-  <a href="https://gitter.im/feross/webtorrent"><img src="https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg" alt="Gitter"></a>
-  <a href="https://travis-ci.org/feross/webtorrent-desktop"><img src="https://img.shields.io/travis/feross/webtorrent-desktop/master.svg" alt="Travis"></a>
-  <a href="https://github.com/feross/webtorrent-desktop/releases"><img src="https://img.shields.io/github/release/feross/webtorrent-desktop.svg" alt="Release"></a>
+  <a href="https://gitter.im/feross/webtorrent">
+    <img src="https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg" alt="Gitter">
+  </a>
+  <a href="https://travis-ci.org/feross/webtorrent-desktop">
+    <img src="https://img.shields.io/travis/feross/webtorrent-desktop/master.svg" alt="Travis">
+  </a>
+  <a href="https://github.com/feross/webtorrent-desktop/releases">
+    <img src="https://img.shields.io/github/release/feross/webtorrent-desktop.svg" alt="Release">
+  </a>
 </p>
 
 ## Install
@@ -68,19 +76,25 @@ $ npm test
 $ npm run test-integration
 ```
 
-The integration tests use Spectron and Tape. They click through the app, taking screenshots and comparing each one to a reference. Why screenshots?
+The integration tests use Spectron and Tape. They click through the app, taking screenshots and
+comparing each one to a reference. Why screenshots?
 
 * Ad-hoc checking makes the tests a lot more work to write
-* Even diffing the whole HTML is not as thorough as screenshot diffing. For example, it wouldn't catch an bug where hitting ESC from a video doesn't correctly restore window size.
+* Even diffing the whole HTML is not as thorough as screenshot diffing. For example, it wouldn't
+  catch an bug where hitting ESC from a video doesn't correctly restore window size.
 * Chrome's own integration tests use screenshot diffing iirc
-* Small UI changes will break a few tests, but the fix is as easy as deleting the offending screenshots and running the tests, which will recreate them with the new look.
-* The resulting Github PR will then show, pixel by pixel, the exact UI changes that were made! Ses https://github.com/blog/817-behold-image-view-modes
+* Small UI changes will break a few tests, but the fix is as easy as deleting the offending
+  screenshots and running the tests, which will recreate them with the new look.
+* The resulting Github PR will then show, pixel by pixel, the exact UI changes that were made! See
+  https://github.com/blog/817-behold-image-view-modes
 
-For MacOS, you'll need a Retina screen for the integration tests to pass. Your screen should have the same resolution as a 2016 12" Macbook.
+For MacOS, you'll need a Retina screen for the integration tests to pass. Your screen should have
+the same resolution as a 2016 12" Macbook.
 
 For Windows, you'll need Windows 10 with a 1366x768 screen.
 
-When running integration tests, keep the mouse on the edge of the screen and don't touch the mouse or keyboard while the tests are running.
+When running integration tests, keep the mouse on the edge of the screen and don't touch the mouse
+or keyboard while the tests are running.
 
 ### Package the app
 
@@ -110,7 +124,7 @@ The following optional arguments are available:
    - `all` - All platforms (default)
 
 Note: Even with the `--package` option, the auto-update files (.nupkg for Windows,
-*-darwin.zip for Mac) will always be produced.
+-darwin.zip for Mac) will always be produced.
 
 #### Windows build notes
 
@@ -148,6 +162,119 @@ torrents you add.
 ### Code Style
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+
+## Release Procedure
+
+### 1. Create a new version
+
+- Update `AUTHORS`
+
+  ```
+  npm run update-authors
+  ```
+
+  Commit if necessary. The commit message should be "authors".
+
+- Write the changelog
+  
+  You can use `git log --oneline <last version tag>..HEAD` to get a list of changes.
+
+  Summarize them concisely in `CHANGELOG.md`. The commit  message should be "changelog".
+
+- Update the version
+
+  ```
+  npm version [major|minor|patch]
+  ```
+
+  This creates both a commit and a git tag.
+
+- Make a PR
+
+  Once the PR is reviewed, merge it:
+
+  ```
+  git push origin <branch-name>:master
+  ```
+
+  This makes it so that the commit hash on master matches the commit hash of the version tag.
+
+  Finally, run:
+
+  ```
+  git push --tags
+  ```
+
+### 2. Create the release binaries
+
+- On a Mac:
+
+  ```
+  npm run package -- darwin --sign
+  npm run package -- linux --sign
+  ```
+
+- On Windows, or in a Windows VM:
+
+  ```
+  npm run package -- win32 --sign
+  ```
+
+- Then, upload the release binaries to Github:
+
+  ```
+  npm run gh-release
+  ```
+
+  Follow the URL to a newly created Github release page. Manually upload the binaries from
+  `webtorrent-desktop/dist/`. Open the previous release in another tab, and make sure that you
+  are uploading the same set of files, no more, no less.
+
+### 3. Test it
+
+**This is the most important part.**
+
+ - Manually download the binaries for each platform from Github.
+
+  **Do not use your locally built binaries.** Modern OSs treat executables differently if they've
+  been downloaded, even though the files are byte for byte identical. This ensures that the
+  codesigning worked and is valid.
+
+- Smoke test WebTorrent Desktop on each platform.
+
+  See Smoke Tests below for details. Open DevTools
+  on Windows and Mac, and ensure that the auto updater is running. If the auto updater does not
+  run, users will successfully auto update to this new version, and then be stuck there forever.
+
+### 4. Ship it
+
+- Update the website
+
+  Create a pull request in [webtorrent.io](https://github.com/feross/webtorrent.io). Update
+  `config.js`, updating the desktop app version.
+
+  As soon as this PR is merged, Jenkins will automatically redeploy the WebTorrent website, and
+  hundreds of thousands of users around the world will start auto updating. **Merge with care.**
+
+## Smoke Tests
+
+Before a release, check that the following basic use cases work correctly:
+
+1. Click "Play" to stream a built-in torrent (e.g. Sintel)
+  - Ensure that seeking to undownloaded region works and plays immediately.
+  - Ensure that sintel.mp4 gets downloaded to `~/Downloads`.
+
+2. Check that the auto-updater works
+  - Open the console and check for the line "No update available" to indicate
+
+3. Add a new .torrent file via drag-and-drop.
+  - Ensure that it gets added to the list and starts downloading
+
+4. Remove a torrent from the client
+  - Ensure that the file is removed from `~/Downloads`
+
+5. Create and seed a new a torrent via drag-and-drop.
+  - Ensure that the torrent gets created and seeding begins.
 
 ## License
 

--- a/bin/package.js
+++ b/bin/package.js
@@ -21,6 +21,7 @@ const pkg = require('../package.json')
 const BUILD_NAME = config.APP_NAME + '-v' + config.APP_VERSION
 const BUILD_PATH = path.join(config.ROOT_PATH, 'build')
 const DIST_PATH = path.join(config.ROOT_PATH, 'dist')
+const NODE_MODULES_PATH = path.join(config.ROOT_PATH, 'node_modules')
 
 const argv = minimist(process.argv.slice(2), {
   boolean: [
@@ -36,6 +37,12 @@ const argv = minimist(process.argv.slice(2), {
 })
 
 function build () {
+  console.log('Reinstalling node_modules...')
+  rimraf.sync(NODE_MODULES_PATH)
+  cp.execSync('npm install', { stdio: 'inherit' })
+  cp.execSync('npm dedupe', { stdio: 'inherit' })
+
+  console.log('Nuking dist/ and build/...')
   rimraf.sync(DIST_PATH)
   rimraf.sync(BUILD_PATH)
 

--- a/bin/release-_post.sh
+++ b/bin/release-_post.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e
-
-npm run update-authors
-git diff --exit-code
-npm run package -- --sign
-git push
-git push --tags
-npm run gh-release

--- a/bin/release-_pre.sh
+++ b/bin/release-_pre.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-git pull
-rm -rf node_modules/
-npm install
-npm dedupe
-npm test

--- a/bin/release-major.sh
+++ b/bin/release-major.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -e
-BIN=`dirname $0`
-
-$BIN/release-_pre.sh
-npm version major
-$BIN/release-_post.sh

--- a/bin/release-minor.sh
+++ b/bin/release-minor.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -e
-BIN=`dirname $0`
-
-$BIN/release-_pre.sh
-npm version minor
-$BIN/release-_post.sh

--- a/bin/release-patch.sh
+++ b/bin/release-patch.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -e
-BIN=`dirname $0`
-
-$BIN/release-_pre.sh
-npm version patch
-$BIN/release-_post.sh


### PR DESCRIPTION
The release scripts don't really work, and there are a lot of manual steps that weren't documented. They are now.