### PR TITLE
Treat .FLAC as playable audio

### DIFF
--- a/src/renderer/lib/torrent-player.js
+++ b/src/renderer/lib/torrent-player.js
@@ -37,6 +37,7 @@ function isAudio (file) {
     '.mp3',
     '.ogg',
     '.wav',
+    '.flac',
     '.m4a'
   ].includes(getFileExtension(file))
 }


### PR DESCRIPTION
Fixes: https://github.com/feross/webtorrent-desktop/issues/1124

Note FLAC is not actually playable in Electron, by default. But this
will at least offer to open it in VLC or the user's preferred player.