### PR TITLE
electron@1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "buble": "^0.15.2",
     "cross-zip": "^2.0.1",
     "depcheck": "^0.6.4",
-    "electron": "1.4.15",
+    "electron": "1.6.0",
     "electron-osx-sign": "0.4.3",
     "electron-packager": "~8.5.1",
     "electron-winstaller": "~2.5.2",


### PR DESCRIPTION
This version of Electron is 3 versions of Chromium newer, so there are
lots of performance improvements.

There is one known issue with this update:
https://github.com/electron/electron/issues/8694 which will be fixed in the next version.

But I think we should merge this anyway so that collaborators can try
out the new Chromium and V8 before we do a release with it. We might
find other bugs.