### PR TITLE
Toggle fullscreen on pinch to zoom

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -24,6 +24,7 @@ const State = require('./lib/state')
 State.load(onState)
 
 const createGetter = require('fn-getter')
+const debounce = require('debounce')
 const dragDrop = require('drag-drop')
 const electron = require('electron')
 const fs = require('fs')
@@ -144,6 +145,18 @@ function onState (err, _state) {
 
   // ...same thing if you paste a torrent
   document.addEventListener('paste', onPaste)
+
+  const debouncedFullscreenToggle = debounce(function () {
+    dispatch('toggleFullScreen')
+  }, 100)
+
+  document.addEventListener('wheel', function (event) {
+    // ctrlKey detects pinch to zoom, http://crbug.com/289887
+    if (event.ctrlKey) {
+      event.preventDefault()
+      debouncedFullscreenToggle()
+    }
+  })
 
   // ...focus and blur. Needed to show correct dock icon text ('badge') in OSX
   window.addEventListener('focus', onFocus)


### PR DESCRIPTION
This patch makes webtorrent to do fullscreen (maximize/unmaximize) when pinch to zoom event (two finger zoom in/out gesture) happened on macOS instead probably less meaningful zoom. Have a look [here](https://github.com/dimsemenov/PhotoSwipe/issues/897) for more info about the approach.

To test this, open webtorrent on mac and do two finger zoom on webtorrent window with and without this patch. The intended gesture matches VLC on pinch to zoom action.

I hope you find this useful. Thanks!